### PR TITLE
Bioconductor submission updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: maaslin3
 Title: "Refining and extending generalized multivariate linear models
         for meta-omic association discovery"
 Year: 2024
-Version: 0.99.1
+Version: 0.99.2
 Authors@R: c(
   person("William", "Nickols", email = "willnickols@g.harvard.edu", role = c("aut", "cre"), comment=c(ORCID="0000-0001-8214-9746")), 
   person("Jacob", "Nearing", email = "nearing@broadinstitute.org", role = "aut")
@@ -12,7 +12,7 @@ Description: MaAsLin 3 refines and extends generalized multivariate linear model
 License: MIT + file LICENSE
 Imports: dplyr, pbapply, lmerTest, parallel, lme4, optparse, logging,
         multcomp, ggplot2, RColorBrewer, patchwork, scales,
-        rlang, tibble, ggnewscale, survival, methods, BiocGenerics, SummarizedExperiment
+        rlang, tibble, ggnewscale, survival, methods, BiocGenerics, SummarizedExperiment, TreeSummarizedExperiment
 Suggests: knitr, testthat (>= 2.1.0), rmarkdown, markdown, kableExtra
 VignetteBuilder: knitr
 Collate: fit.R utility_scripts.R viz.R maaslin3.R

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -19,7 +19,7 @@ export(preprocess_dna_mtx)
 
 import("optparse")
 importFrom("stats", "as.formula", "coef", "glm", "lm", "na.exclude",
-    "p.adjust", "update", "relevel", "anova", "approx", "filter", "median",    "model.matrix", "pbeta", "quantile", "terms",    "update.formula", "var", "vcov", "rnorm", "cov")
+    "p.adjust", "update", "relevel", "anova", "approx", "filter", "median",    "model.matrix", "pbeta", "quantile", "terms",    "update.formula", "var", "vcov", "rnorm", "cov", "setNames")
 importFrom("utils", "capture.output", "read.table", "write.table")
 importFrom("dplyr", "%>%")
 importFrom("stats", "sd", "na.omit")
@@ -27,3 +27,4 @@ importFrom("utils","type.convert")
 importFrom("rlang", ".data")
 importFrom("methods", "is")
 importFrom("survival", "strata", "coxph", "Surv")
+importFrom("TreeSummarizedExperiment", "TreeSummarizedExperiment")

--- a/R/fit.R
+++ b/R/fit.R
@@ -59,6 +59,7 @@ safe_deparse <- function(formula) {
 
 # Extract a predictor of the form: predictor_type(variable)
 extract_special_predictor <- function(formula, predictor_type) {
+    match.arg(predictor_type, c("group", "ordered", "strata"))
     groups <-
         regmatches(safe_deparse(formula), gregexpr(
             paste0(predictor_type, "\\((.*?)\\)"),
@@ -141,11 +142,9 @@ get_fixed_effects <-
                 names_to_include[names_to_include != "(Intercept)"]
         }
         
-        ordered_levels <- c()
-        for (ordered in ordereds) {
-            ordered_levels <- c(ordered_levels, 
-                                paste0(ordered, levels(dat_sub[[ordered]])[-1]))
-        }
+        ordered_levels <- unlist(lapply(ordereds, function(ordered) {
+            paste0(ordered, levels(dat_sub[[ordered]])[-1])
+        }))
         
         names_to_include <-
             c(names_to_include, groups, ordered_levels)
@@ -154,8 +153,7 @@ get_fixed_effects <-
 
 # Get non-baseline names for all non-numeric columns
 get_character_cols <- function(dat_sub) {
-    all_factors <- c()
-    for (col in colnames(dat_sub)) {
+    all_factors <- unlist(lapply(colnames(dat_sub), function(col) {
         if (!is.numeric(dat_sub[, col])) {
             if (is.factor(dat_sub[, col])) {
                 factor_levels <- levels(dat_sub[, col])
@@ -163,15 +161,18 @@ get_character_cols <- function(dat_sub) {
                 factor_levels <- levels(factor(dat_sub[, col]))
             }
             # All factor levels except baseline
-            all_factors <-
-                c(all_factors, paste0(col, unique(factor_levels[-1])))
+            return(unlist(paste0(col, unique(factor_levels[-1]))))
         }
-    }
+        return(character(0))
+    }))
+    
     return(all_factors)
 }
 
 # Correct over prevalence and abundance to get q-values
 add_qvals <- function(fit_data_abundance, fit_data_prevalence, correction) {
+    match.arg(correction, 
+        c("BH", "holm", "hochberg", "hommel", "bonferroni", "BY"))
     # Select out p-values and NA if errors
     if (!is.null(fit_data_abundance)) {
         abundance_pvals <- fit_data_abundance$results$pval
@@ -212,6 +213,8 @@ add_qvals <- function(fit_data_abundance, fit_data_prevalence, correction) {
 
 # Combine abundance and prevalence p-values
 create_combined_pval <- function(merged_signif, correction) {
+    match.arg(correction,
+            c("BH", "holm", "hochberg", "hommel", "bonferroni", "BY"))
     # Create a combined p-value
     merged_signif$pval_joint <-
         pbeta(pmin(merged_signif[, "linear"],
@@ -279,6 +282,8 @@ add_joint_signif <-
             new_fit_data_abundance,
             max_significance,
             correction) {
+        match.arg(correction,
+            c("BH", "holm", "hochberg", "hommel", "bonferroni", "BY"))
         # Subset to shared columns
         fit_data_prevalence_signif <-
             fit_data_prevalence$results[, c("feature", "metadata", "value",
@@ -951,6 +956,7 @@ check_for_zero_one_obs <- function(formula,
                                     x,
                                     model,
                                     feature_specific_covariate_name) {
+    match.arg(model, c("linear", "logistic"))
     if (length(unique(dat_sub$expr)) < 2) {
         output <- list()
         
@@ -1002,10 +1008,11 @@ check_missing_first_factor_level <- function(formula,
                                             x,
                                             feature_specific_covariate_name) {
     missing_first_factor_level <- FALSE
-    for (col in colnames(dat_sub)) {
+    missing_first_factor_level <- any(c(vapply(colnames(dat_sub), 
+                                                function(col) {
         if (is.factor(dat_sub[, col])) {
             if (all(is.na(dat_sub$expr[dat_sub[, col] == 
-                                    levels(dat_sub[, col])[1]]))) {
+                                        levels(dat_sub[, col])[1]]))) {
                 fixed_effects <-
                     get_fixed_effects(formula,
                                     random_effects_formula,
@@ -1014,11 +1021,12 @@ check_missing_first_factor_level <- function(formula,
                                     ordereds,
                                     feature_specific_covariate_name)
                 if (col %in% substr(fixed_effects, 1, nchar(col))) {
-                    missing_first_factor_level <- TRUE
+                    return(TRUE)
                 }
             }
         }
-    }
+        return(FALSE)
+    }, logical(1))))
     
     if (missing_first_factor_level) {
         output <- list()
@@ -1226,8 +1234,10 @@ run_group_models <- function(ranef_function,
                             dat_sub,
                             output,
                             mm_input) {
-    for (group in groups) {
-        output$para <- tryCatch({
+    match.arg(model, c("linear", "logistic"))
+    output$para <- rbind(output$para,
+                        setNames(do.call(rbind, lapply(groups, function(group) {
+        setNames(tryCatch({
             withCallingHandlers({
                 # Catch non-integer # successes first
                 if (is.null(random_effects_formula)) {
@@ -1296,12 +1306,12 @@ run_group_models <- function(ranef_function,
                     } else {
                         contrast_mat <- matrix(0, ncol = length(
                             lme4::fixef(fit)),
-                                nrow = length(levels(dat_sub[[group]])[-1])
-                            )
+                            nrow = length(levels(dat_sub[[group]])[-1])
+                        )
                         contrast_mat[seq_along(levels(
                             dat_sub[[group]])[-1]),
                             which(names(lme4::fixef(fit)) %in% paste0(
-                                    group, levels(dat_sub[[group]])[-1]))] <-
+                                group, levels(dat_sub[[group]])[-1]))] <-
                             diag(1, nrow = length(levels(dat_sub[[group]])[-1]))
                         
                         pval_new <- tryCatch({
@@ -1311,33 +1321,38 @@ run_group_models <- function(ranef_function,
                                 rhs = 
                                     rep(0, length(levels(
                                         dat_sub[[group]])[-1])))[['Pr(>F)']]
-                            },
-                            error = function(err) {
-                                NA
-                            })
+                        },
+                        error = function(err) {
+                            NA
+                        })
                     }
                 }
                 
-                tmp_output <-
-                    rbind(output$para,
-                        list(NA, NA, pval_new, group))
+                tmp_output <- list(NA, NA, pval_new, group)
+                tmp_output
             }, warning = function(w) {
-                if (w$message == 
-                    "non-integer #successes in a binomial glm!") {
-                    # Still worked
+                if (w$message == "non-integer #successes in a binomial glm!") {
                     invokeRestart("muffleWarning")
                 }
             })
-        },
-        warning = function(w) {
-            rbind(output$para, list(NA, NA, NA, group))
-        },
-        error = function(err) {
-            rbind(output$para, list(NA, NA, NA, group))
-        })
-        rownames(output$para) <-
-            c(rownames(output$para)[-nrow(output$para)], group)
-    }
+        }, warning = function(w) {
+            return(list(NA, NA, NA, group))
+        }, error = function(err) {
+            return(list(NA, NA, NA, group))
+        }), names(output$para))
+    })), names(output$para)))
+    
+    tmp_rownames <- rownames(output$para)
+    
+    output$para <- data.frame(lapply(output$para, function(x) {
+        if (is.list(x)) unlist(x) else x
+    }), check.names = FALSE)
+    
+    rownames(output$para) <- tmp_rownames
+    
+    rownames(output$para) <- c(rownames(output$para)[
+        -seq((nrow(output$para) - length(groups) + 1), nrow(output$para))], 
+        groups)
     return(output)
 }
 
@@ -1354,9 +1369,12 @@ run_ordered_models <- function(ranef_function,
                             weight_scheme,
                             dat_sub,
                             output) {
-    for (ordered in ordereds) {
+    match.arg(model, c("linear", "logistic"))
+    output$para <- rbind(output$para,
+                        setNames(do.call(rbind, lapply(ordereds, 
+                            function(ordered) {
         ordered_levels <- paste0(ordered, levels(dat_sub[[ordered]])[-1])
-        output$para <- tryCatch({
+        setNames(tryCatch({
             withCallingHandlers({
                 # Catch non-integer # successes first
                 if (is.null(random_effects_formula)) {
@@ -1382,57 +1400,36 @@ run_ordered_models <- function(ranef_function,
                         contrast_mat[i + 1, cols_to_add_1s[i]] <- -1
                     }
                     
-                    pvals_new <- c()
-                    coefs_new <- c()
-                    sigmas_new <- c()
-                    for (row_num in seq(nrow(contrast_mat))) {
-                        contrast_vec <- t(matrix(contrast_mat[row_num,]))
-                        pvals_new <-
-                            c(pvals_new, tryCatch({
-                                summary(multcomp::glht(
-                                    fit,
-                                    linfct = contrast_vec,
-                                    rhs = 0,
-                                    coef. = function(x) {
-                                        coef(x, complete = FALSE)
-                                    }
-                                    )
-                                )$test$pvalues
-                            },
-                            error = function(err) {
-                                NA
-                            }))
-                        coefs_new <-
-                            c(coefs_new, tryCatch({
-                                summary(multcomp::glht(
-                                    fit,
-                                    linfct = contrast_vec,
-                                    rhs = 0,
-                                    coef. = function(x) {
-                                        coef(x, complete = FALSE)
-                                    }
-                                    )
-                                )$test$coefficients
-                            },
-                            error = function(err) {
-                                NA
-                            }))
-                        sigmas_new <-
-                            c(sigmas_new, tryCatch({
-                                summary(multcomp::glht(
-                                    fit,
-                                    linfct = contrast_vec,
-                                    rhs = 0,
-                                    coef. = function(x) {
-                                        coef(x, complete = FALSE)
-                                    }
-                                    )
-                                )$test$sigma
-                            },
-                            error = function(err) {
-                                NA
-                            }))
-                    }
+                    pvals_new <- vapply(seq(nrow(contrast_mat)), 
+                                        function(row_num) {
+                        contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                        tryCatch({
+                            summary(multcomp::glht(fit, linfct = contrast_vec, 
+                rhs = 0, 
+                coef. = function(x) { coef(x, complete = FALSE) }))$test$pvalues
+                        }, error = function(err) { NA })
+                    }, numeric(1))
+                    
+                    coefs_new <- vapply(seq(nrow(contrast_mat)), 
+                                        function(row_num) {
+                        contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                        tryCatch({
+                            summary(multcomp::glht(fit, linfct = contrast_vec, 
+                rhs = 0, 
+                coef. = function(x) { 
+                    coef(x, complete = FALSE) }))$test$coefficients
+                        }, error = function(err) { NA })
+                    }, numeric(1))
+                    
+                    sigmas_new <- vapply(seq(nrow(contrast_mat)), 
+                                        function(row_num) {
+                        contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                        tryCatch({
+                            summary(multcomp::glht(fit, linfct = contrast_vec, 
+                rhs = 0, 
+                coef. = function(x) { coef(x, complete = FALSE) }))$test$sigma
+                        }, error = function(err) { NA })
+                    }, numeric(1))
                 } else {
                     # Random effects
                     if (any(!ordered_levels %in% names(lme4::fixef(fit)))) {
@@ -1443,7 +1440,7 @@ run_ordered_models <- function(ranef_function,
                     
                     contrast_mat <-
                         matrix(0, ncol = length(lme4::fixef(fit)),
-                            nrow = length(levels(dat_sub[[ordered]])[-1])
+                                nrow = length(levels(dat_sub[[ordered]])[-1])
                         )
                     
                     cols_to_add_1s <-
@@ -1455,108 +1452,77 @@ run_ordered_models <- function(ranef_function,
                     }
                     
                     if (model == "logistic") {
-                        pvals_new <- c()
-                        coefs_new <- c()
-                        sigmas_new <- c()
-                        for (row_num in seq(nrow(contrast_mat))) {
-                            contrast_vec <- t(matrix(contrast_mat[row_num,]))
-                            pvals_new <-
-                                c(pvals_new,
-                                tryCatch({
-                                    summary(multcomp::glht(
-                                            fit,
-                                            linfct = contrast_vec,
-                                            rhs = 0
-                                        )
-                                    )$test$pvalues
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                            coefs_new <-
-                                c(coefs_new,
-                                tryCatch({
-                                    summary(multcomp::glht(
-                                            fit,
-                                            linfct = contrast_vec,
-                                            rhs = 0
-                                        )
-                                    )$test$coefficients
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                            sigmas_new <-
-                                c(sigmas_new,
-                                tryCatch({
-                                    summary(multcomp::glht(
-                                        fit,
-                                        linfct = contrast_vec,
-                                        rhs = 0
-                                        )
-                                    )$test$sigma
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                        }
+        pvals_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    summary(multcomp::glht(fit, linfct = contrast_vec, 
+                                        rhs = 0, 
+                                        coef. = function(x) { coef(x, 
+                                        complete = FALSE) }))$test$pvalues
+                }, error = function(err) { NA })
+            }, numeric(1))
+                        
+        coefs_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    summary(multcomp::glht(fit, linfct = contrast_vec, 
+                                        rhs = 0, 
+                                        coef. = function(x) { 
+                                        coef(x, 
+                                        complete = FALSE) }))$test$coefficients
+                }, error = function(err) { NA })
+            }, numeric(1))
+                        
+        sigmas_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    summary(multcomp::glht(fit, linfct = contrast_vec, 
+                    rhs = 0, 
+                    coef. = function(x) { 
+                    coef(x, complete = FALSE) }))$test$sigma
+                }, error = function(err) { NA })
+            }, numeric(1))
                     } else {
-                        pvals_new <- c()
-                        coefs_new <- c()
-                        sigmas_new <- c()
-                        for (row_num in seq(nrow(contrast_mat))) {
-                            contrast_vec <- t(matrix(contrast_mat[row_num,]))
-                            pvals_new <-
-                                c(pvals_new,
-                                tryCatch({
-                                    lmerTest::contest(fit,
-                                                        matrix(
-                                                            contrast_vec,
-                                                            TRUE
-                                                        ), rhs = 0)[['Pr(>F)']]
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                            coefs_new <-
-                                c(coefs_new,
-                                tryCatch({
-                                    contrast_vec %*% lme4::fixef(fit)
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                            sigmas_new <-
-                                c(sigmas_new,
-                                tryCatch({
-                                    sqrt((
-                                        contrast_vec %*% 
-                                            vcov(fit) %*% 
-                                            t(contrast_vec)
-                                    )[1, 1])
-                                },
-                                error = function(err) {
-                                    NA
-                                }))
-                        }
-                    }
+        pvals_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    lmerTest::contest(fit,
+                                        matrix(
+                                        contrast_vec,
+                                        TRUE
+                                        ), rhs = 0)[['Pr(>F)']]
+                }, error = function(err) { NA })
+            }, numeric(1))
+        
+        coefs_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    contrast_vec %*% lme4::fixef(fit)
+                }, error = function(err) { NA })
+            }, numeric(1))
+        
+        sigmas_new <- vapply(seq(nrow(contrast_mat)), 
+            function(row_num) {
+                contrast_vec <- t(matrix(contrast_mat[row_num, ]))
+                tryCatch({
+                    sqrt((contrast_vec %*% vcov(fit) %*% t(contrast_vec))[1, 1])
+                }, error = function(err) { NA })
+            }, numeric(1))
+            }
                 }
                 
                 tmp_output <-
-                    rbind(
-                        output$para,
-                        list(
-                            coefs_new,
-                            sigmas_new,
-                            pvals_new,
-                            ordered_levels
+                    data.frame(coefs_new,
+                        sigmas_new,
+                        pvals_new,
+                        ordered_levels
                         )
-                    )
-                rownames(tmp_output)[
-                    (nrow(tmp_output) - 
-                        length(ordered_levels) + 1):
-                        nrow(tmp_output)] <-
-                    ordered_levels
+                rownames(tmp_output) <- ordered_levels
                 tmp_output
             }, warning = function(w) {
                 if (w$message == 
@@ -1565,34 +1531,28 @@ run_ordered_models <- function(ranef_function,
                     invokeRestart("muffleWarning")
                 }
             })
-        },
-        warning = function(w) {
-            org_row_num <- nrow(output$para)
-            output$para[
-                (org_row_num + 1):(org_row_num + length(ordered_levels)), 
-                seq(3)] <- NA
-            output$para[
-                (org_row_num + 1):(org_row_num + length(ordered_levels)), 
-                4] <- ordered_levels
-            rownames(output$para)[
-                (org_row_num + 1):(org_row_num + length(ordered_levels))] <-
+        }, warning = function(w) {
+            tmp_output <- data.frame(matrix(nrow = length(ordered_levels),
+                                            ncol = 4))
+            tmp_output[seq(1,length(ordered_levels)), seq(3)] <- NA
+            tmp_output[seq(1,length(ordered_levels)), 4] <- ordered_levels
+            rownames(tmp_output)[seq(1,length(ordered_levels))] <-
                 ordered_levels
-            output$para
-        },
-        error = function(err) {
-            org_row_num <- nrow(output$para)
-            output$para[
-                (org_row_num + 1):(org_row_num + length(ordered_levels)), 
-                seq(3)] <- NA
-            output$para[
-                (org_row_num + 1):(org_row_num + length(ordered_levels)), 
-                4] <- ordered_levels
-            rownames(output$para)[
-                (org_row_num + 1):(org_row_num + length(ordered_levels))] <-
+            
+            return(tmp_output)
+        }, error = function(err) {
+            tmp_output <- data.frame(matrix(nrow = length(ordered_levels),
+                                            ncol = 4))
+            tmp_output[seq(1,length(ordered_levels)), seq(3)] <- NA
+            tmp_output[seq(1,length(ordered_levels)), 4] <- ordered_levels
+            rownames(tmp_output)[seq(1,length(ordered_levels))] <-
                 ordered_levels
-            output$para
-        })
-    }
+            
+            return(tmp_output)
+        }), names(output$para))
+    })),
+    names(output$para)))
+    
     return(output)
 }
 
@@ -1698,6 +1658,7 @@ run_median_comparison_ordered <- function(paras_sub,
                                         pvals_new,
                                         cur_median,
                                         model) {
+    match.arg(model, c("linear", "logistic"))
     
     ordered <- ordereds[which(startsWith(
         metadata_variable, ordereds))]
@@ -1714,225 +1675,215 @@ run_median_comparison_ordered <- function(paras_sub,
     
     # MC for covariance
     nsims <- 10000
-    sim_medians <- vector(length = nsims)
-    all_sims <- matrix(ncol = n_coefs, nrow = nsims)
-    for (j in seq(nsims)) {
+    
+    sim_results <- replicate(nsims, {
         sim_coefs <- rnorm(n_coefs, coefs, sigmas)
-        sim_medians[j] <- median(sim_coefs[use_this_coef])
-        all_sims[j,] <- sim_coefs
-    }
-    cov_adjust <- apply(all_sims, 2, function(x){cov(x, sim_medians)})
+        sim_median <- median(sim_coefs[use_this_coef])
+        c(sim_median, sim_coefs)
+    })
+    
+    sim_medians <- sim_results[1, ]
+    all_sims <- sim_results[-1, , drop = FALSE]
+    cov_adjust <- apply(all_sims, 1, function(x){cov(x, sim_medians)})
     
     # Necessary offsets for contrast testing
     offsets_to_test <- abs(cur_median - coefs) * 
         sqrt((sigmas^2) / (sigmas^2+ sd_median^2 - 2 * cov_adjust)) + coefs
     
-    for (row_index in seq(nrow(paras_sub))) {
-        feature <- paras_sub$feature[row_index]
-        if (is.null(random_effects_formula)) {
-            # Fixed effects
-            cur_fit <- fits[[feature]]
-            
-            if (!metadata_variable %in% names(coef(cur_fit))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            if (any(!paste0(ordered, 
-                            levels(
-                                metadata[[ordered]])[-1]) %in% 
-                    names(coef(cur_fit)))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            mm_variable <-
-                model.matrix(cur_fit)[, metadata_variable]
-            if (any(!unique(
-                mm_variable[!is.na(mm_variable)]) %in% c(0, 1))) {
-                median_comparison_threshold_updated <-
-                    median_comparison_threshold / 
-                    sd(mm_variable)
-            } else {
-                median_comparison_threshold_updated <- 
-                    median_comparison_threshold
-            }
-            
-            if (is.na(coef(cur_fit, complete = FALSE)[
-                which(names(coef(
-                    cur_fit, complete = FALSE
-                )) == metadata_variable)])) {
-                pval_new_current <- NA
-            } else if (abs(coef(cur_fit, complete = FALSE)[
-                which(names(coef(
-                    cur_fit, complete = FALSE
-                )) == metadata_variable)] -
-                cur_median) < median_comparison_threshold_updated) {
-                pval_new_current <- 1
-            } else {
-                contrast_mat <-
-                    matrix(0,
-                        ncol = length(
-                            coef(cur_fit, complete = FALSE)),
-                        nrow = length(levels(
-                            metadata[[ordered]])[-1])
-                    )
+    pvals_new <- c(pvals_new,
+        vapply(seq(nrow(paras_sub)), function(row_index) {
+            feature <- paras_sub$feature[row_index]
+            if (is.null(random_effects_formula)) {
+                # Fixed effects
+                cur_fit <- fits[[feature]]
                 
-                cols_to_add_1s <-
-                    which(names(
-                        coef(cur_fit, complete = FALSE)
-                    ) %in% paste0(ordered, levels(
-                        metadata[[ordered]]
-                    )[-1]))
-                contrast_mat[1, cols_to_add_1s[1]] <- 1
-                for (i in seq_along(cols_to_add_1s[-1])) {
-                    contrast_mat[i + 1, cols_to_add_1s[-1][i]] <- 1
-                    contrast_mat[i + 1, cols_to_add_1s[i]] <- -1
+                if (!metadata_variable %in% names(coef(cur_fit))) {
+                    return(NA)
                 }
                 
-                contrast_vec <-
-                    t(matrix(contrast_mat[which(paste0(
-                        ordered, levels(
-                            metadata[[ordered]]
-                        )[-1]) == metadata_variable),]))
-                pval_new_current <-
-                    tryCatch({
-                        summary(
-                            multcomp::glht(
-                                cur_fit,
-                                linfct = contrast_vec,
-                                rhs = offsets_to_test[row_index],
-                                coef. = function(x) {
-                                    coef(x, complete = FALSE)
-                                }
-                            )
-                        )$test$pvalues
-                    },
-                    error = function(err) {
-                        NA
-                    })
-            }
-            
-            pvals_new <-
-                c(pvals_new, pval_new_current)
-        } else {
-            # Random effects
-            cur_fit <- fits[[feature]]
-            
-            if (!metadata_variable %in% 
-                names(lme4::fixef(cur_fit))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            if (any(!paste0(ordered, 
-                            levels(metadata[[
-                                ordered]])[-1]) %in% 
-                    names(lme4::fixef(cur_fit)))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            mm_variable <-
-                model.matrix(cur_fit)[, metadata_variable]
-            if (any(
-                !unique(mm_variable[!is.na(mm_variable)]) %in% 
-                c(0, 1))) {
-                median_comparison_threshold_updated <-
-                    median_comparison_threshold / 
-                    sd(mm_variable)
-            } else {
-                median_comparison_threshold_updated <- 
-                    median_comparison_threshold
-            }
-            
-            contrast_mat <-
-                matrix(
-                    0,
-                    ncol = length(lme4::fixef(cur_fit)),
-                    nrow = length(levels(
-                        metadata[[ordered]])[-1])
-                )
-            cols_to_add_1s <-
-                which(names(lme4::fixef(cur_fit)) %in% 
-                        paste0(ordered, levels(
-                            metadata[[ordered]])[-1]))
-            contrast_mat[1, cols_to_add_1s[1]] <- 1
-            for (i in seq_along(cols_to_add_1s[-1])) {
-                contrast_mat[i + 1, cols_to_add_1s[-1][i]] <- 1
-                contrast_mat[i + 1, cols_to_add_1s[i]] <-
-                    -1
-            }
-            contrast_vec <-
-                t(matrix(
-                    contrast_mat[
-                        which(paste0(
-                            ordered, levels(metadata[[
-                                ordered]])[-1]) == 
-                                metadata_variable),]))
-            
-            if (model == "logistic") {
-                if (is.na(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
+                if (any(!paste0(ordered, 
+                                levels(
+                                    metadata[[ordered]])[-1]) %in% 
+                        names(coef(cur_fit)))) {
+                    return(NA)
+                }
+                
+                mm_variable <-
+                    model.matrix(cur_fit)[, metadata_variable]
+                if (any(!unique(
+                    mm_variable[!is.na(mm_variable)]) %in% c(0, 1))) {
+                    median_comparison_threshold_updated <-
+                        median_comparison_threshold / 
+                        sd(mm_variable)
+                } else {
+                    median_comparison_threshold_updated <- 
+                        median_comparison_threshold
+                }
+                
+                if (is.na(coef(cur_fit, complete = FALSE)[
+                    which(names(coef(
+                        cur_fit, complete = FALSE
                     )) == metadata_variable)])) {
                     pval_new_current <- NA
-                } else if (abs(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
+                } else if (abs(coef(cur_fit, complete = FALSE)[
+                    which(names(coef(
+                        cur_fit, complete = FALSE
                     )) == metadata_variable)] -
-                    cur_median) < 
-                    median_comparison_threshold_updated) {
+                    cur_median) < median_comparison_threshold_updated) {
                     pval_new_current <- 1
                 } else {
+                    contrast_mat <-
+                        matrix(0, ncol = length(
+                            coef(cur_fit, complete = FALSE)),
+                            nrow = length(levels(metadata[[ordered]])[-1])
+                        )
+                    
+                    cols_to_add_1s <-
+                        which(names(coef(cur_fit, complete = FALSE)) %in% 
+                            paste0(ordered, levels(metadata[[ordered]])[-1]))
+                    contrast_mat[1, cols_to_add_1s[1]] <- 1
+                    for (i in seq_along(cols_to_add_1s[-1])) {
+                        contrast_mat[i + 1, cols_to_add_1s[-1][i]] <- 1
+                        contrast_mat[i + 1, cols_to_add_1s[i]] <- -1
+                    }
+                    
+                    contrast_vec <-
+                        t(matrix(contrast_mat[which(paste0(
+                            ordered, levels(
+                                metadata[[ordered]]
+                            )[-1]) == metadata_variable),]))
                     pval_new_current <-
                         tryCatch({
                             summary(
                                 multcomp::glht(
                                     cur_fit,
                                     linfct = contrast_vec,
-                                    rhs = offsets_to_test[row_index]
+                                    rhs = offsets_to_test[row_index],
+                                    coef. = function(x) {
+                                        coef(x, complete = FALSE)
+                                    }
                                 )
                             )$test$pvalues
                         },
                         error = function(err) {
                             NA
                         })
-                } 
-                pvals_new <-
-                    c(pvals_new, pval_new_current)
-            } else {
-                if (is.na(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
-                    )) == metadata_variable)])) {
-                    pval_new_current <- NA
-                } else if (abs(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
-                    )) == metadata_variable)] -
-                    cur_median) < 
-                    median_comparison_threshold_updated) {
-                    pval_new_current <- 1
-                } else {
-                    pval_new_current <-
-                        tryCatch({
-                            lmerTest::contest(cur_fit,
-                                            matrix(contrast_vec, 
-                                                    TRUE),
-                                            rhs = offsets_to_test[row_index])[[
-                                                'Pr(>F)']]
-                        },
-                        error = function(err) {
-                            NA
-                        })
                 }
                 
-                pvals_new <-
-                    c(pvals_new, pval_new_current)
+                return(pval_new_current)
+            } else {
+                # Random effects
+                cur_fit <- fits[[feature]]
+                
+                if (!metadata_variable %in% 
+                    names(lme4::fixef(cur_fit))) {
+                    NA
+                }
+                
+                if (any(!paste0(ordered, 
+                                levels(metadata[[
+                                    ordered]])[-1]) %in% 
+                        names(lme4::fixef(cur_fit)))) {
+                    NA
+                }
+                
+                mm_variable <-
+                    model.matrix(cur_fit)[, metadata_variable]
+                if (any(
+                    !unique(mm_variable[!is.na(mm_variable)]) %in% 
+                    c(0, 1))) {
+                    median_comparison_threshold_updated <-
+                        median_comparison_threshold / 
+                        sd(mm_variable)
+                } else {
+                    median_comparison_threshold_updated <- 
+                        median_comparison_threshold
+                }
+                
+                contrast_mat <-
+                    matrix(
+                        0,
+                        ncol = length(lme4::fixef(cur_fit)),
+                        nrow = length(levels(
+                            metadata[[ordered]])[-1])
+                    )
+                cols_to_add_1s <-
+                    which(names(lme4::fixef(cur_fit)) %in% 
+                        paste0(ordered, levels(
+                        metadata[[ordered]])[-1]))
+                contrast_mat[1, cols_to_add_1s[1]] <- 1
+                for (i in seq_along(cols_to_add_1s[-1])) {
+                    contrast_mat[i + 1, cols_to_add_1s[-1][i]] <- 1
+                    contrast_mat[i + 1, cols_to_add_1s[i]] <- -1
+                }
+                contrast_vec <-
+                    t(matrix(
+                        contrast_mat[
+                            which(paste0(
+                                ordered, levels(metadata[[
+                                    ordered]])[-1]) == 
+                                    metadata_variable),]))
+                
+                if (model == "logistic") {
+                    if (is.na(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)])) {
+                        pval_new_current <- NA
+                    } else if (abs(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)] -
+                        cur_median) < 
+                        median_comparison_threshold_updated) {
+                        pval_new_current <- 1
+                    } else {
+                        pval_new_current <-
+                            tryCatch({
+                                summary(
+                                    multcomp::glht(
+                                        cur_fit,
+                                        linfct = contrast_vec,
+                                        rhs = offsets_to_test[row_index]
+                                    )
+                                )$test$pvalues
+                            },
+                            error = function(err) {
+                                NA
+                            })
+                    } 
+                    return(pval_new_current)
+                } else {
+                    if (is.na(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)])) {
+                        pval_new_current <- NA
+                    } else if (abs(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)] -
+                        cur_median) < 
+                        median_comparison_threshold_updated) {
+                        pval_new_current <- 1
+                    } else {
+                        pval_new_current <-
+                            tryCatch({
+                                lmerTest::contest(cur_fit,
+                                            matrix(contrast_vec, TRUE),
+                                            rhs = offsets_to_test[row_index])[[
+                                                'Pr(>F)']]
+                            },
+                            error = function(err) {
+                                NA
+                            })
+                    }
+                    
+                    return(pval_new_current)
+                }
             }
-        }
-    }
+        }, numeric(1)))
+    
     return(pvals_new)
 }
 
@@ -1946,6 +1897,7 @@ run_median_comparison_general <- function(paras_sub,
                                         pvals_new,
                                         cur_median,
                                         model) {
+    match.arg(model, c("linear", "logistic"))
     use_this_coef <- !is.na(paras_sub$pval) & paras_sub$pval < 0.95
     
     n_coefs <- nrow(paras_sub)
@@ -1958,124 +1910,62 @@ run_median_comparison_general <- function(paras_sub,
 
     # MC for covariance
     nsims <- 10000
-    sim_medians <- vector(length = nsims)
-    all_sims <- matrix(ncol = n_coefs, nrow = nsims)
-    for (j in seq(nsims)) {
+    sim_results <- replicate(nsims, {
         sim_coefs <- rnorm(n_coefs, coefs, sigmas)
-        sim_medians[j] <- median(sim_coefs[use_this_coef])
-        all_sims[j,] <- sim_coefs
-    }
-    cov_adjust <- apply(all_sims, 2, function(x){cov(x, sim_medians)})
+        sim_median <- median(sim_coefs[use_this_coef])
+        c(sim_median, sim_coefs)
+    })
+    
+    sim_medians <- sim_results[1, ]
+    all_sims <- sim_results[-1, , drop = FALSE]
+    cov_adjust <- apply(all_sims, 1, function(x){cov(x, sim_medians)})
     
     # Necessary offsets for contrast testing
     offsets_to_test <- abs(cur_median - coefs) * 
         sqrt((sigmas^2) / (sigmas^2+ sd_median^2 - 2 * cov_adjust)) + coefs
     
-    for (row_index in seq(nrow(paras_sub))) {
-        feature <- paras_sub$feature[row_index]
-        if (is.null(random_effects_formula)) {
-            # Fixed effects
-            cur_fit <- fits[[feature]]
-            
-            if (!metadata_variable %in% names(coef(cur_fit))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            mm_variable <-
-                model.matrix(cur_fit)[, metadata_variable]
-            if (any(
-                !unique(mm_variable[!is.na(mm_variable)]) %in% 
-                c(0, 1))) {
-                median_comparison_threshold_updated <-
-                    median_comparison_threshold / 
-                    sd(mm_variable)
-            } else {
-                median_comparison_threshold_updated <- 
-                    median_comparison_threshold
-            }
-            
-            contrast_vec <-
-                rep(0, length(coef(
+    pvals_new <- c(pvals_new,
+        vapply(seq(nrow(paras_sub)), function(row_index) {
+            feature <- paras_sub$feature[row_index]
+            if (is.null(random_effects_formula)) {
+                # Fixed effects
+                cur_fit <- fits[[feature]]
+                
+                if (!metadata_variable %in% names(coef(cur_fit))) {
+                    return(NA)
+                }
+                
+                mm_variable <-
+                    model.matrix(cur_fit)[, metadata_variable]
+                if (any(
+                    !unique(mm_variable[!is.na(mm_variable)]) %in% 
+                    c(0, 1))) {
+                    median_comparison_threshold_updated <-
+                        median_comparison_threshold / 
+                        sd(mm_variable)
+                } else {
+                    median_comparison_threshold_updated <- 
+                        median_comparison_threshold
+                }
+                
+                contrast_vec <-
+                    rep(0, length(coef(
+                        cur_fit, complete = FALSE
+                    )))
+                contrast_vec[which(names(coef(
                     cur_fit, complete = FALSE
-                )))
-            contrast_vec[which(names(coef(
-                cur_fit, complete = FALSE
-            )) == metadata_variable)] <- 1
-            
-            if (is.na(coef(cur_fit, complete = FALSE)[
-                which(names(coef(
-                    cur_fit, complete = FALSE
-                )) == metadata_variable)])) {
-                pval_new_current <- NA
-            } else if (abs(coef(cur_fit, complete = FALSE)[
-                which(names(coef(
-                    cur_fit, complete = FALSE
-                )) == metadata_variable)] -
-                cur_median) < median_comparison_threshold_updated) {
-                pval_new_current <- 1
-            } else {
-                pval_new_current <-
-                    tryCatch({
-                        summary(
-                            multcomp::glht(
-                                cur_fit,
-                                linfct = matrix(contrast_vec, 
-                                                TRUE),
-                                rhs = offsets_to_test[row_index],
-                                coef. = function(x) {
-                                    coef(x, complete = FALSE)
-                                }
-                            )
-                        )$test$pvalues[1]
-                    },
-                    error = function(err) {
-                        NA
-                    })
-            }
-            
-            pvals_new <-
-                c(pvals_new, pval_new_current)
-        } else {
-            # Random effects
-            cur_fit <- fits[[feature]]
-            
-            if (!metadata_variable %in% 
-                names(lme4::fixef(cur_fit))) {
-                pvals_new <- c(pvals_new, NA)
-                next
-            }
-            
-            mm_variable <-
-                model.matrix(cur_fit)[, metadata_variable]
-            if (any(!unique(
-                mm_variable[!is.na(mm_variable)]) %in% 
-                c(0, 1))) {
-                median_comparison_threshold_updated <-
-                    median_comparison_threshold / 
-                    sd(mm_variable)
-            } else {
-                median_comparison_threshold_updated <- 
-                    median_comparison_threshold
-            }
-            
-            contrast_vec <-
-                rep(0, length(lme4::fixef(cur_fit)))
-            contrast_vec[which(names(lme4::fixef(cur_fit)) == 
-                                metadata_variable)] <- 1
-            
-            if (model == "logistic") {
-                if (is.na(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
+                )) == metadata_variable)] <- 1
+                
+                if (is.na(coef(cur_fit, complete = FALSE)[
+                    which(names(coef(
+                        cur_fit, complete = FALSE
                     )) == metadata_variable)])) {
                     pval_new_current <- NA
-                } else if (abs(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
+                } else if (abs(coef(cur_fit, complete = FALSE)[
+                    which(names(coef(
+                        cur_fit, complete = FALSE
                     )) == metadata_variable)] -
-                    cur_median) < 
-                    median_comparison_threshold_updated) {
+                    cur_median) < median_comparison_threshold_updated) {
                     pval_new_current <- 1
                 } else {
                     pval_new_current <-
@@ -2083,9 +1973,12 @@ run_median_comparison_general <- function(paras_sub,
                             summary(
                                 multcomp::glht(
                                     cur_fit,
-                                    linfct = matrix(
-                                        contrast_vec, TRUE),
-                                    rhs = offsets_to_test[row_index]
+                                    linfct = matrix(contrast_vec, 
+                                                    TRUE),
+                                    rhs = offsets_to_test[row_index],
+                                    coef. = function(x) {
+                                        coef(x, complete = FALSE)
+                                    }
                                 )
                             )$test$pvalues[1]
                         },
@@ -2094,39 +1987,95 @@ run_median_comparison_general <- function(paras_sub,
                         })
                 }
                 
-                pvals_new <-
-                    c(pvals_new, pval_new_current)
+                return(pval_new_current)
             } else {
-                if (is.na(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
-                    )) == metadata_variable)])) {
-                    pval_new_current <- NA
-                } else if (abs(lme4::fixef(cur_fit)[
-                    which(names(lme4::fixef(
-                        cur_fit
-                    )) == metadata_variable)] -
-                    cur_median) < 
-                    median_comparison_threshold_updated) {
-                    pval_new_current <- 1
-                } else {
-                    pval_new_current <-
-                        tryCatch({
-                            lmerTest::contest(
-                                cur_fit,
-                                matrix(contrast_vec, TRUE),
-                                rhs = offsets_to_test[row_index])[['Pr(>F)']]
-                        },
-                        error = function(err) {
-                            NA
-                        })
+                # Random effects
+                cur_fit <- fits[[feature]]
+                
+                if (!metadata_variable %in% 
+                    names(lme4::fixef(cur_fit))) {
+                    return(NA)
                 }
                 
-                pvals_new <-
-                    c(pvals_new, pval_new_current)
+                mm_variable <-
+                    model.matrix(cur_fit)[, metadata_variable]
+                if (any(!unique(
+                    mm_variable[!is.na(mm_variable)]) %in% 
+                    c(0, 1))) {
+                    median_comparison_threshold_updated <-
+                        median_comparison_threshold / 
+                        sd(mm_variable)
+                } else {
+                    median_comparison_threshold_updated <- 
+                        median_comparison_threshold
+                }
+                
+                contrast_vec <- rep(0, length(lme4::fixef(cur_fit)))
+                contrast_vec[which(names(lme4::fixef(cur_fit)) == 
+                            metadata_variable)] <- 1
+                
+                if (model == "logistic") {
+                    if (is.na(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)])) {
+                        pval_new_current <- NA
+                    } else if (abs(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)] -
+                        cur_median) < 
+                        median_comparison_threshold_updated) {
+                        pval_new_current <- 1
+                    } else {
+                        pval_new_current <-
+                            tryCatch({
+                                summary(
+                                    multcomp::glht(
+                                        cur_fit,
+                                        linfct = matrix(
+                                            contrast_vec, TRUE),
+                                        rhs = offsets_to_test[row_index]
+                                    )
+                                )$test$pvalues[1]
+                            },
+                            error = function(err) {
+                                NA
+                            })
+                    }
+                    
+                    return(pval_new_current)
+                } else {
+                    if (is.na(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)])) {
+                        pval_new_current <- NA
+                    } else if (abs(lme4::fixef(cur_fit)[
+                        which(names(lme4::fixef(
+                            cur_fit
+                        )) == metadata_variable)] -
+                        cur_median) < 
+                        median_comparison_threshold_updated) {
+                        pval_new_current <- 1
+                    } else {
+                        pval_new_current <-
+                            tryCatch({
+                                lmerTest::contest(
+                                    cur_fit,
+                                    matrix(contrast_vec, TRUE),
+                                    rhs = 
+                                    offsets_to_test[row_index])[['Pr(>F)']]
+                            },
+                            error = function(err) {
+                                NA
+                            })
+                    }
+                    
+                    return(pval_new_current)
+                }
             }
-        }
-    }
+        }, numeric(1)))
     return(pvals_new)
 }
 
@@ -2140,15 +2089,13 @@ run_median_comparison <- function(paras,
                                 median_comparison_threshold,
                                 subtract_median,
                                 model) {
+    match.arg(model, c("linear", "logistic"))
     logging::loginfo("Performing tests against medians")
     
     if (length(ordereds) > 0) {
-        ordered_levels <- c()
-        for (ordered in ordereds) {
-            ordered_levels <-
-                c(ordered_levels, paste0(ordered, 
-                                        levels(metadata[[ordered]])[-1]))
-        }
+        ordered_levels <- unlist(lapply(ordereds, function(ordered) {
+            unlist(paste0(ordered, levels(metadata[[ordered]])[-1]))
+        }))
     } else {
         ordered_levels <- c()
     }
@@ -2157,14 +2104,22 @@ run_median_comparison <- function(paras,
         paras[!is.na(paras$error) | paras$name %in% groups,]
     paras <-
         paras[is.na(paras$error) & !paras$name %in% groups,]
-    for (metadata_variable in unique(paras$name)) {
-        paras_sub <- paras[paras$name == metadata_variable,]
+    
+    process_metadata_variable <- function(metadata_variable,
+                                        paras,
+                                        fits,
+                                        ordered_levels,
+                                        ordereds,
+                                        metadata,
+                                        random_effects_formula, 
+                                        median_comparison_threshold, 
+                                        subtract_median, 
+                                        model) {
         
-        # Get the current median, excluding coefficients with NA p-values or
-        # p-values close to 1 since these could be model misfits
-        cur_median <-
-            median(paras_sub$coef[!is.na(paras_sub$pval) &
-                                    paras_sub$pval < 0.95], na.rm = TRUE)
+        paras_sub <- paras[paras$name == metadata_variable, ]
+        cur_median <- median(paras_sub$coef[!is.na(paras_sub$pval) & 
+                                        paras_sub$pval < 0.95], na.rm = TRUE)
+        
         if (is.na(cur_median)) {
             pvals_new <- rep(NA, nrow(paras_sub))
             coefs_new <- paras_sub$coef
@@ -2175,44 +2130,63 @@ run_median_comparison <- function(paras,
             } else {
                 coefs_new <- paras_sub$coef
             }
+            
             if (metadata_variable %in% ordered_levels) {
                 pvals_new <- run_median_comparison_ordered(
-                    paras_sub,
-                    fits,
-                    ordereds,
-                    metadata,
-                    random_effects_formula,
-                    median_comparison_threshold,
-                    metadata_variable,
-                    pvals_new,
-                    cur_median,
-                    model)
+                    paras_sub, 
+                    fits, 
+                    ordereds, 
+                    metadata, 
+                    random_effects_formula, 
+                    median_comparison_threshold, 
+                    metadata_variable, 
+                    pvals_new, 
+                    cur_median, 
+                    model
+                )
             } else {
                 pvals_new <- run_median_comparison_general(
-                    paras_sub,
-                    fits,
-                    metadata,
-                    random_effects_formula,
-                    median_comparison_threshold,
-                    metadata_variable,
-                    pvals_new,
-                    cur_median,
-                    model)
+                    paras_sub, 
+                    fits, 
+                    metadata, 
+                    random_effects_formula, 
+                    median_comparison_threshold, 
+                    metadata_variable, 
+                    pvals_new, 
+                    cur_median, 
+                    model
+                )
             }
         }
         
-        paras_sub$error <-
-            ifelse(
-                is.na(pvals_new) & !is.na(paras_sub$pval),
-                "P-value became NA in median comparison, 
-                    try rerunning without the median comparison",
-                paras_sub$error
-            )
+        paras_sub$error <- ifelse(
+            is.na(pvals_new) & !is.na(paras_sub$pval), 
+            "P-value became NA in median comparison, 
+            try rerunning without the median comparison", 
+            paras_sub$error
+        )
+        
         paras_sub$pval <- pvals_new
         paras_sub$coef <- coefs_new
-        final_paras <- rbind(final_paras, paras_sub)
+        
+        return(paras_sub)
     }
     
+    final_paras_list <- lapply(unique(paras$name), function(metadata_variable) {
+        process_metadata_variable(metadata_variable,
+                                paras,
+                                fits,
+                                ordered_levels,
+                                ordereds,
+                                metadata,
+                                random_effects_formula,
+                                median_comparison_threshold,
+                                subtract_median,
+                                model)
+    })
+    
+    final_paras <- rbind(final_paras, do.call(rbind, final_paras_list))
+
     paras <- final_paras
     return(paras)
 }
@@ -2233,6 +2207,9 @@ fit.model <- function(features,
                     feature_specific_covariate = NULL,
                     feature_specific_covariate_name = NULL,
                     feature_specific_covariate_record = NULL) {
+    match.arg(model, c("linear", "logistic"))
+    match.arg(correction, 
+            c("BH", "holm", "hochberg", "hommel", "bonferroni", "BY"))
     check_formulas_valid(formula, random_effects_formula)
     formula <- formula(formula)
     

--- a/R/utility_scripts.R
+++ b/R/utility_scripts.R
@@ -203,59 +203,45 @@ write_fits <- function(output,
         logging::loginfo("Creating fits folder")
         dir.create(fits_folder)
     }
+
+    model_types <- c('linear', 'logistic')
     
-    
-    for (model_type in c('linear', 'logistic')) {
-        if (model_type == 'linear') {
-            fit_data <- fit_data_abundance
+    lapply(model_types, function(model_type) {
+        fit_data <- if (model_type == 'linear') {
+            fit_data_abundance
         } else {
-            fit_data <- fit_data_prevalence
+            fit_data_prevalence
         }
         
-        if (is.null(fit_data)) {
-            next
-        }
+        if (is.null(fit_data)) return(NULL)
         
-        ################################
-        # Write out the raw model fits #
-        ################################
-        
+        # Write out the raw model fits
         if (save_models) {
-            model_file <-
-                file.path(fits_folder,
-                        paste0("models_", model_type, ".rds"))
-            # remove models file if already exists (since models append)
+            model_file <- file.path(fits_folder, 
+                                    paste0("models_", model_type, ".rds"))
             if (file.exists(model_file)) {
-                logging::logwarn("Deleting existing model objects file: %s",
-                                model_file)
+                logging::logwarn("Deleting existing model objects file: %s", 
+                                    model_file)
                 unlink(model_file)
             }
             logging::loginfo("Writing model objects to file %s", model_file)
             saveRDS(fit_data$fits, file = model_file)
         }
         
-        ###########################
-        # Write residuals to file #
-        ###########################
-        
-        residuals_file <-
-            file.path(fits_folder, paste0("residuals_", model_type, ".rds"))
-        # remove residuals file if already exists (since residuals append)
+        # Write residuals to file
+        residuals_file <- file.path(fits_folder, 
+                                    paste0("residuals_", model_type, ".rds"))
         if (file.exists(residuals_file)) {
-            logging::logwarn("Deleting existing residuals file: %s",
+            logging::logwarn("Deleting existing residuals file: %s", 
                             residuals_file)
             unlink(residuals_file)
         }
         logging::loginfo("Writing residuals to file %s", residuals_file)
         saveRDS(fit_data$residuals, file = residuals_file)
         
-        ###############################
-        # Write fitted values to file #
-        ###############################
-        
-        fitted_file <-
-            file.path(fits_folder, paste0("fitted_", model_type, ".rds"))
-        # remove fitted file if already exists (since fitted append)
+        # Write fitted values to file
+        fitted_file <- file.path(fits_folder, 
+                                paste0("fitted_", model_type, ".rds"))
         if (file.exists(fitted_file)) {
             logging::logwarn("Deleting existing fitted file: %s", fitted_file)
             unlink(fitted_file)
@@ -263,23 +249,19 @@ write_fits <- function(output,
         logging::loginfo("Writing fitted values to file %s", fitted_file)
         saveRDS(fit_data$fitted, file = fitted_file)
         
-        #########################################################
-        # Write extracted random effects to file (if specified) #
-        #########################################################
-        
+        # Write extracted random effects to file (if specified)
         if (!is.null(random_effects_formula)) {
-            ranef_file <-
-                file.path(fits_folder, paste0("ranef_", model_type, ".rds"))
-            # remove ranef file if already exists (since ranef append)
+            ranef_file <- file.path(fits_folder, 
+                                    paste0("ranef_", model_type, ".rds"))
             if (file.exists(ranef_file)) {
                 logging::logwarn("Deleting existing ranef file: %s", ranef_file)
                 unlink(ranef_file)
             }
-            logging::loginfo("Writing extracted random effects to file %s",
+            logging::loginfo("Writing extracted random effects to file %s", 
                             ranef_file)
             saveRDS(fit_data$ranef, file = ranef_file)
         }
-    }
+    })
 }
 
 write_results <- function(output,
@@ -362,32 +344,30 @@ write_results <- function(output,
 
 write_results_in_lefse_format <-
     function(results, output_file_name) {
-        lines_vec <- vector(length = nrow(results))
-        for (i in seq(nrow(results))) {
-            if (is.na(results[i, ]$error) &
+        lines_vec <- vapply(seq(nrow(results)), function(i) {
+            if (is.na(results[i, ]$error) & 
                 !is.na(results[i, ]$qval_individual)) {
                 if (results[i, ]$qval_individual < 0.1) {
-                    lines_vec[i] <- paste0(
+                    return(paste0(
                         c(
                             results[i, ]$feature,
                             results[i, ]$coef,
                             paste0(results[i, ]$metadata, '_', 
-                                results[i, ]$value),
+                                    results[i, ]$value),
                             results[i, ]$coef,
                             results[i, ]$pval_individual
                         ),
                         collapse = '\t'
-                    )
+                    ))
                 } else {
-                    lines_vec[i] <- paste0(c(results[i, ]$feature,
-                                            results[i, ]$coef,
-                                            "",
-                                            "",
-                                            "-"),
-                                        collapse = '\t')
+                    return(paste0(c(results[i, ]$feature, 
+                            results[i, ]$coef, "", "", "-"), collapse = '\t'))
                 }
+            } else {
+                # return NA for rows that don't meet the condition
+                return(NA_character_)
             }
-        }
+        }, FUN.VALUE = character(1))
         lines_vec <- lines_vec[lines_vec != 'FALSE']
         
         writeLines(sort(lines_vec), con = output_file_name)
@@ -449,25 +429,15 @@ maaslin_contrast_test <- function(fits,
         stop("Number of rows in contrast matrix must equal the length of rhs")
     }
     
-    pvals_new <- vector(length = length(fits) * nrow(contrast_mat))
-    coefs_new <- vector(length = length(fits) * nrow(contrast_mat))
-    sigmas_new <- vector(length = length(fits) * nrow(contrast_mat))
-    errors <- vector(length = length(fits) * nrow(contrast_mat))
-    
     # Run contrast test on each  model
-    for (fit_index in seq_along(fits)) {
-        fit <- fits[[fit_index]]
+    test_out_joined <- do.call(rbind, 
+        lapply(seq_along(fits), function(fit_index) {
+                fit <- fits[[fit_index]]
         if (!is(fit, 'lmerMod') & !is(fit, 'glmerMod') & !is(fit, "coxph")) {
             if (all(is.na(fit))) {
-                pvals_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                            ((fit_index) * nrow(contrast_mat))] <- NA
-                coefs_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                            ((fit_index) * nrow(contrast_mat))] <- NA
-                sigmas_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                            ((fit_index) * nrow(contrast_mat))] <- NA
-                errors[((fit_index - 1) * nrow(contrast_mat) + 1):
-                        ((fit_index) * nrow(contrast_mat))] <- "Fit is NA"
-                next
+                return(matrix(rep(c(NA, NA, NA, "Fit is NA"), 
+                            nrow(contrast_mat)),
+                            nrow = nrow(contrast_mat), byrow = TRUE))
             }
         }
         
@@ -481,126 +451,111 @@ maaslin_contrast_test <- function(fits,
         contrast_mat_tmp <- contrast_mat
         contrast_mat_tmp <- cbind(contrast_mat_tmp, 
                                 matrix(0, 
-                                        nrow = nrow(contrast_mat_tmp),
-                                        ncol = length(
-                                            setdiff(included_coefs,
-                                                    contrast_mat_cols))))
+                                    nrow = nrow(contrast_mat_tmp),
+                                    ncol = length(
+                                    setdiff(included_coefs,
+                                    contrast_mat_cols))))
         colnames(contrast_mat_tmp) <- c(contrast_mat_cols,
                                         setdiff(included_coefs,
                                                 contrast_mat_cols))
         if (any(contrast_mat_tmp[,setdiff(contrast_mat_cols, 
                                         included_coefs)] != 0)) {
-            pvals_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                        ((fit_index) * nrow(contrast_mat))] <- NA
-            coefs_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                        ((fit_index) * nrow(contrast_mat))] <- NA
-            sigmas_new[((fit_index - 1) * nrow(contrast_mat) + 1):
-                        ((fit_index) * nrow(contrast_mat))] <- NA
-            errors[((fit_index - 1) * nrow(contrast_mat) + 1):
-                    ((fit_index) * nrow(contrast_mat))] <- 
-                "Predictors not in the model had non-zero contrast values"
-            next
+            return(matrix(rep(c(NA, NA, NA, 
+                "Predictors not in the model had non-zero contrast values"), 
+                    nrow(contrast_mat)),
+                    nrow = nrow(contrast_mat), byrow = TRUE))
         }
         
         contrast_mat_tmp <- contrast_mat_tmp[,included_coefs, drop = FALSE]
         
         # Run contrast test
         if (!uses_random_effects | model == 'prevalence') {
-            for (row_num in seq(nrow(contrast_mat))) {
-                contrast_vec <- t(matrix(contrast_mat_tmp[row_num,]))
-                
-                error_message <- NA
-                calling_env <- environment()
-                test_out <- tryCatch({
-                    if (!uses_random_effects) {
-                        summary_out <- summary(multcomp::glht(
-                            fit,
-                            linfct = contrast_vec,
-                            rhs = rhs[row_num],
-                            coef. = function(x) {
-                                coef(x, complete = FALSE)
-                            }
-                        )
-                        )$test
-                    } else {
-                        summary_out <- summary(multcomp::glht(
-                            fit,
-                            linfct = contrast_vec,
-                            rhs = rhs[row_num],
-                        )
-                        )$test
-                    }
+            test_out_joined <- vapply(X = seq(nrow(contrast_mat)), 
+                FUN = function(row_num) {
+                    contrast_vec <- t(matrix(contrast_mat_tmp[row_num,]))
                     
-                    c(summary_out$pvalues,
-                    summary_out$coefficients,
-                    summary_out$sigma)
-                }, warning = function(w) {
-                    message(sprintf("Feature %s : %s", 
-                                    names(fit), w))
-                    
-                    assign("error_message",
-                        conditionMessage(w),
-                        envir = calling_env)
-                    invokeRestart("muffleWarning")
-                },
-                error = function(err) {
-                    assign("error_message", err$message, envir = calling_env)
-                    error_obj <- c(NA, NA, NA)
-                    return(error_obj)
-                })
-                pvals_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[1]
-                coefs_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[2]
-                sigmas_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[3] 
-                errors[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    error_message
-            }
+                    error_message <- NA
+                    calling_env <- environment()
+                    test_out <- tryCatch({
+                        if (!uses_random_effects) {
+                            summary_out <- summary(multcomp::glht(
+                                fit,
+                                linfct = contrast_vec,
+                                rhs = rhs[row_num],
+                                coef. = function(x) {
+                                    coef(x, complete = FALSE)
+                                }
+                            )
+                            )$test
+                        } else {
+                            summary_out <- summary(multcomp::glht(
+                                fit,
+                                linfct = contrast_vec,
+                                rhs = rhs[row_num],
+                            )
+                            )$test
+                        }
+                        
+                        c(summary_out$coefficients,
+                            summary_out$sigma,
+                            summary_out$pvalues)
+                    }, warning = function(w) {
+                        message(sprintf("Feature %s : %s", 
+                                        names(fit), w))
+                        
+                        assign("error_message",
+                                conditionMessage(w),
+                                envir = calling_env)
+                        invokeRestart("muffleWarning")
+                    },
+                    error = function(err) {
+                        assign("error_message", err$message, 
+                            envir = calling_env)
+                        error_obj <- c(NA, NA, NA)
+                        return(error_obj)
+                    })
+                    return(as.character(c(test_out, error_message)))
+                }, character(4))
         } else {
-            for (row_num in seq(nrow(contrast_mat))) {
-                contrast_vec <- t(matrix(contrast_mat_tmp[row_num,]))
-                
-                error_message <- NA
-                calling_env <- environment()
-                test_out <- tryCatch({
-                    pval <- lmerTest::contest(fit,
-                                            matrix(
-                                                contrast_vec,
-                                                TRUE
-                                            ), rhs = rhs[row_num])[['Pr(>F)']]
-                    coef <- contrast_vec %*% lme4::fixef(fit)
-                    sigma <- sqrt((contrast_vec %*% vcov(fit) %*% 
-                                    t(contrast_vec))[1, 1])
-                    c(pval,
-                    coef,
-                    sigma)
-                }, warning = function(w) {
-                    message(sprintf("Feature %s : %s", 
-                                    names(fit), w))
+            test_out_joined <- vapply(X = seq(nrow(contrast_mat)), 
+                FUN = function(row_num) {
+                    contrast_vec <- t(matrix(contrast_mat_tmp[row_num,]))
                     
-                    assign("error_message",
-                        conditionMessage(w),
-                        envir = calling_env)
-                    invokeRestart("muffleWarning")
-                },
-                error = function(err) {
-                    assign("error_message", err$message, envir = calling_env)
-                    error_obj <- c(NA, NA, NA)
-                    return(error_obj)
-                })
-                pvals_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[1]
-                coefs_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[2]
-                sigmas_new[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    test_out[3] 
-                errors[((fit_index - 1) * nrow(contrast_mat) + row_num)] <- 
-                    error_message
-            }
+                    error_message <- NA
+                    calling_env <- environment()
+                    test_out <- tryCatch({
+                        pval <- lmerTest::contest(fit,
+                            matrix(contrast_vec, TRUE), 
+                            rhs = rhs[row_num])[['Pr(>F)']]
+                        coef <- contrast_vec %*% lme4::fixef(fit)
+                        sigma <- sqrt((contrast_vec %*% vcov(fit) %*% 
+                                        t(contrast_vec))[1, 1])
+                        c(coef, sigma, pval)
+                    }, warning = function(w) {
+                        message(sprintf("Feature %s : %s", names(fit), w))
+                        
+                        assign("error_message",
+                                conditionMessage(w),
+                                envir = calling_env)
+                        invokeRestart("muffleWarning")
+                    },
+                    error = function(err) {
+                        assign("error_message", err$message,
+                            envir = calling_env)
+                        error_obj <- c(NA, NA, NA)
+                        return(error_obj)
+                    })
+                    return(as.character(c(test_out, error_message)))
+                }, character(4))
         }
-    }
+        return(t(test_out_joined))
+    }))
     
+    test_out_joined <- data.frame(test_out_joined)
+    colnames(test_out_joined) <- c("coefs_new", "sigmas_new", 
+        "pvals_new", "errors")
+    test_out_joined[, seq(3)] <- apply(test_out_joined[, seq(3)], 2, as.numeric)
+
     if (all(is.null(rownames(contrast_mat)))) {
         test_names <- seq(nrow(contrast_mat))
     } else {
@@ -611,29 +566,31 @@ maaslin_contrast_test <- function(fits,
     paras <- data.frame(
         feature = rep(names(fits), each = nrow(contrast_mat)),
         test = rep(test_names, length(fits)),
-        coef = coefs_new,
+        coef = test_out_joined$coefs_new,
         rhs = rep(rhs, length(fits)),
-        stderr = sigmas_new,
-        pval_individual = pvals_new,
-        error = errors,
+        stderr = test_out_joined$sigmas_new,
+        pval_individual = test_out_joined$pvals_new,
+        error = test_out_joined$errors,
         model = model
     )
     
     # Perform median comparison as though these were the original fits
     if (median_comparison) {
-        for (selected_test in unique(paras$test)) {
-            paras_sub <- paras[paras$test == selected_test & 
-                                !is.na(paras$coef) & 
-                                !is.na(paras$stderr), , drop = FALSE]
+        paras <- do.call(rbind, lapply(unique(paras$test), 
+                                        function(selected_test) {
+            paras_sub <- paras[paras$test == selected_test, , drop = FALSE]
+            paras_sub_out <- paras_sub[is.na(paras_sub$coef) | 
+                                        is.na(paras_sub$stderr), , drop = FALSE]
+            paras_sub <- paras_sub[!is.na(paras_sub$coef) & 
+                                    !is.na(paras_sub$stderr), , drop = FALSE]
             if (nrow(paras_sub) == 0) {
-                next
+                return(paras_sub_out)
             }
             
             # Make sure other p-values are set to NA to not confuse
             # median comparison with non-comparison
-            paras$pval_individual[paras$test == selected_test & 
-                                    is.na(paras$coef) | 
-                                    is.na(paras$stderr)] <- NA
+            paras_sub_out$pval_individual <- rep(NA, 
+                length(paras_sub_out$pval_individual))
             
             use_this_coef <- !is.na(paras_sub$pval_individual) & 
                 paras_sub$pval_individual < 0.95
@@ -647,31 +604,30 @@ maaslin_contrast_test <- function(fits,
             
             # Variance from asymptotic distribution
             sd_median <- sqrt(0.25 * 2 * base::pi * 
-                                sigma_sq_med / sum(use_this_coef))
+                            sigma_sq_med / sum(use_this_coef))
             
             # MC for covariance
             nsims <- 10000
-            sim_medians <- vector(length = nsims)
-            all_sims <- matrix(ncol = n_coefs, nrow = nsims)
-            for (j in seq(nsims)) {
+            
+            sim_results <- replicate(nsims, {
                 sim_coefs <- rnorm(n_coefs, coefs, sigmas)
-                sim_medians[j] <- median(sim_coefs[use_this_coef])
-                all_sims[j,] <- sim_coefs
-            }
-            cov_adjust <- apply(all_sims, 2, function(x){cov(x, sim_medians)})
+                sim_median <- median(sim_coefs[use_this_coef])
+                c(sim_median, sim_coefs)
+            })
+            
+            sim_medians <- sim_results[1, ]
+            all_sims <- sim_results[-1, , drop = FALSE]
+            cov_adjust <- apply(all_sims, 1, function(x){cov(x, sim_medians)})
             
             # Necessary offsets for contrast testing
             offsets_to_test <- abs(cur_median - coefs) * 
                 sqrt((sigmas^2) / (sigmas^2+ sd_median^2 - 2 * cov_adjust)) + 
                 coefs
             
-            pvals_new <- vector(length = nrow(paras_sub))
-            
-            # Run contrast test on each  model
-            for (row_index in seq(nrow(paras_sub))) {
+            pvals_new <- vapply(seq_len(nrow(paras_sub)), function(row_index) {
                 feature <- paras_sub$feature[row_index]
                 fit <- fits[[feature]]
-
+                
                 # Fill in contrast matrix gaps if necessary
                 if (uses_random_effects) {
                     included_coefs <- names(lme4::fixef(fit))
@@ -682,117 +638,71 @@ maaslin_contrast_test <- function(fits,
                 contrast_mat_tmp <- contrast_mat
                 contrast_mat_tmp <- cbind(contrast_mat_tmp, 
                                         matrix(0, 
-                                                nrow = nrow(contrast_mat_tmp),
-                                                ncol = length(
-                                                setdiff(included_coefs,
-                                                contrast_mat_cols))))
-                colnames(contrast_mat_tmp) <- c(contrast_mat_cols,
-                                                setdiff(included_coefs,
-                                                        contrast_mat_cols))
-
-                contrast_mat_tmp <- contrast_mat_tmp[,included_coefs, 
-                                                    drop = FALSE]
+                                        nrow = nrow(contrast_mat_tmp),
+                                        ncol = length(setdiff(
+                                        included_coefs, contrast_mat_cols))))
+                colnames(contrast_mat_tmp) <- 
+                    c(contrast_mat_cols, 
+                        setdiff(included_coefs, contrast_mat_cols))
+                
+                contrast_mat_tmp <- 
+                    contrast_mat_tmp[, included_coefs, drop = FALSE]
                 
                 # Run contrast test
-                if (!uses_random_effects | model == 'prevalence') {
-                    contrast_vec <- t(matrix(contrast_mat_tmp[selected_test,]))
+                contrast_vec <- t(matrix(contrast_mat_tmp[selected_test,]))
+                
+                error_message <- NA
+                calling_env <- environment()
+                test_out <- tryCatch({
+                    if (!uses_random_effects | model == 'prevalence') {
+                        summary_out <- summary(multcomp::glht(
+                            fit,
+                            linfct = contrast_vec,
+                            rhs = offsets_to_test[row_index],
+                            coef. = function(x) { coef(x, complete = FALSE) }
+                        ))$test
+                    } else {
+                        summary_out <- summary(multcomp::glht(
+                            fit,
+                            linfct = contrast_vec,
+                            rhs = offsets_to_test[row_index]
+                        ))$test
+                    }
                     
-                    error_message <- NA
-                    calling_env <- environment()
-                    test_out <- tryCatch({
-                        if (!uses_random_effects) {
-                            summary_out <- summary(multcomp::glht(
-                                fit,
-                                linfct = contrast_vec,
-                                rhs = offsets_to_test[row_index],
-                                coef. = function(x) {
-                                    coef(x, complete = FALSE)
-                                }
-                            )
-                            )$test
-                        } else {
-                            summary_out <- summary(multcomp::glht(
-                                fit,
-                                linfct = contrast_vec,
-                                rhs = offsets_to_test[row_index],
-                            )
-                            )$test
-                        }
-                        
-                        c(summary_out$pvalues,
-                            summary_out$coefficients,
-                            summary_out$sigma)
-                    }, warning = function(w) {
-                        message(sprintf("Feature %s : %s", 
-                                        names(fit), w))
-                        
-                        assign("error_message",
-                                conditionMessage(w),
-                                envir = calling_env)
-                        invokeRestart("muffleWarning")
-                    },
-                    error = function(err) {
-                        assign("error_message", err$message, 
-                                envir = calling_env)
-                        error_obj <- c(NA, NA, NA)
-                        return(error_obj)
-                    })
-                    pvals_new[row_index] <- 
-                        test_out[1]
-                } else {
-                    contrast_vec <- t(matrix(contrast_mat_tmp[selected_test,]))
+                    c(summary_out$pvalues, summary_out$coefficients, 
+                        summary_out$sigma)
+                }, warning = function(w) {
+                    message(sprintf("Feature %s : %s", names(fit), w))
                     
-                    error_message <- NA
-                    calling_env <- environment()
-                    test_out <- tryCatch({
-                        pval <- lmerTest::contest(fit,
-                                                    matrix(
-                                                        contrast_vec,
-                                                        TRUE
-                                                    ), 
-                                rhs = offsets_to_test[row_index])[['Pr(>F)']]
-                        coef <- contrast_vec %*% lme4::fixef(fit)
-                        sigma <- sqrt((contrast_vec %*% vcov(fit) %*% 
-                                        t(contrast_vec))[1, 1])
-                        c(pval, coef, sigma)
-                    }, warning = function(w) {
-                        message(sprintf("Feature %s : %s", 
-                                        names(fit), w))
-                        
-                        assign("error_message",
-                                conditionMessage(w),
-                                envir = calling_env)
-                        invokeRestart("muffleWarning")
-                    },
-                    error = function(err) {
-                        assign("error_message", err$message, 
-                                envir = calling_env)
-                        error_obj <- c(NA, NA, NA)
-                        return(error_obj)
-                    })
-                    pvals_new[row_index] <- 
-                        test_out[1]
-                }
-            }
+                    assign("error_message", conditionMessage(w), 
+                        envir = calling_env)
+                    invokeRestart("muffleWarning")
+                }, error = function(err) {
+                    assign("error_message", err$message, envir = calling_env)
+                    error_obj <- c(NA, NA, NA)
+                    return(error_obj)
+                })
+                
+                return(test_out[1])
+            }, numeric(1))
             
-            paras$error[paras$test == selected_test & 
-                        !is.na(paras$coef) & 
-                        !is.na(paras$stderr)] <- 
-                ifelse(!is.na(paras$pval_individual[
-                                paras$test == selected_test & 
-                                !is.na(paras$coef) & 
-                                !is.na(paras$stderr)]) & 
-                            is.na(pvals_new),
-                        "P-value became NA during median comparison",
-                        paras$error[paras$test == selected_test & 
-                                    !is.na(paras$coef) & 
-                                    !is.na(paras$stderr)]
+            paras_sub$error <- 
+                ifelse(!is.na(paras_sub$pval_individual) & 
+                        is.na(pvals_new),
+                    "P-value became NA during median comparison",
+                    paras_sub$error
                 )
             
-            paras$pval_individual[paras$test == selected_test & 
-                                !is.na(paras$coef) & 
-                                !is.na(paras$stderr)] <- pvals_new
-        }
+            paras_sub$pval_individual <- pvals_new
+            paras_sub$rhs <- offsets_to_test
+            
+            return(rbind(paras_sub, paras_sub_out))
+        }))
+    }
+    
+    if (!is.null(rownames(paras)) && 
+        !any(is.na(as.numeric(rownames(paras))))) {
+        paras <- paras[order(as.numeric(rownames(paras))),]
     }
     
     return(paras)
@@ -866,14 +776,19 @@ preprocess_dna_mtx <- function(dna_table, rna_table) {
     # samples x features with same samples
     
     dna_table <- TSSnorm(dna_table, 0)
-    for (col_index in seq(ncol(dna_table))) {
-        dna_table[, col_index][is.na(dna_table[, col_index])] <- 0
-    }
-    
+    dna_table <- apply(dna_table, 2, function(x) {
+        x[is.na(x)] <- 0
+        return(x)
+    })
+    dna_table <- as.data.frame(dna_table)
+
     rna_table <- TSSnorm(rna_table, 0)
-    for (col_index in seq(ncol(rna_table))) {
-        rna_table[, col_index][is.na(rna_table[, col_index])] <- 0
-    }
+    rna_table <- apply(rna_table, 2, function(x) {
+        x[is.na(x)] <- 0
+        return(x)
+    })
+    rna_table <- as.data.frame(rna_table)
+    
     
     # Transforming DNA table
     impute_val <- log2(min(dna_table[dna_table > 0]) / 2)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ bioRxiv 2024.12.13.628459; doi: https://doi.org/10.1101/2024.12.13.628459
 ### Support ###
 Check out the [MaAsLin 3
 tutorial](https://github.com/biobakery/biobakery/wiki/MaAsLin3) for an
-overview of analysis options and some example runs.
+overview of analysis options and some example runs. If using vignettes,
+users should start with the `maaslin3_tutorial.Rmd` vignette and then
+refer to the `maaslin3_manual.Rmd` vignette as necessary.
 
 If you have questions, please direct them to the [MaAsLin 3
 Forum](https://forum.biobakery.org/c/Downstream-analysis-and-statistics/maaslin)
@@ -60,19 +62,16 @@ function.
 
 #### Install using GitHub and devtools
 
-The latest development version of MaAsLin 3 can be installed from GitHub
-using the `devtools` package.
+The latest version of MaAsLin 3 can be installed from BiocManager.
 
 ```
-# Install devtools if not present
-if (!require('devtools', character.only = TRUE)) {
-    install.packages('devtools')
-}
+if (!require("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
 
-# Install MaAsLin 3
-library("devtools")
-install_github("biobakery/maaslin3")
+BiocManager::install("biobakery/maaslin3")
 ```
+
+To compile vignettes yourself, specify `dependencies = TRUE`.
 
 ```
 for (lib in c('maaslin3', 'dplyr', 'ggplot2', 'knitr')) {
@@ -661,6 +660,26 @@ complex models.)
 save them to an RData file.
 * `verbosity` (default `'FINEST'`): The level of verbosity for the 
 `logging` package.
+* `save_plots_rds` (default `FALSE`): Whether to save the plots as RDS files.
+
+## Tool comparison ##
+
+| Tool | Models differential abundance | \
+Models differential prevalence | Models allowed | Accounts for\
+compositionality | Can use experimental absolute abundance information |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| MaAsLin 3 | Yes | Yes, for any model type | Any lme4 model\
+(general mixed models), level-vs-level differences, group-wise differences, \
+feature-specific covariates, contrast tests | Yes | Yes |
+| MaAsLin 2 | Yes | Only insofar as it affects abundance | Fixed and random \
+effects (subset of general mixed models) | No | No |
+| ANCOM-BC2 | Yes | Only when completely absent in a group | Any lme4 model \
+(general mixed models), level-vs-level differences, group-wise differences, \
+contrast tests | Yes | No |
+| ALDEx2 | Yes | Only insofar as it affects abundance | Fixed \
+effects | Yes | No |
+| LinDA | Yes | Only insofar as it affects abundance | Any lme4 model \
+(general mixed models), group-wise differences, contrast tests | Yes | No |
 
 ## Troubleshooting ##
 

--- a/man/maaslin3.Rd
+++ b/man/maaslin3.Rd
@@ -57,13 +57,15 @@ maaslin3(input_data,
     max_pngs = 30,
     cores = 1,
     save_models = FALSE,
+    save_plots_rds = FALSE,
     verbosity = 'FINEST',
     summary_plot_balanced = FALSE)
 }
 \arguments{
     \item{input_data}{A data frame of feature abundances or read counts, a
     filepath to a tab-delimited file with abundances, or a SummarizedExperiment
-    object with the taxa table in `assays` and metadata in `colData`. 
+    or TreeSummarizedExperiment object with the taxa table in `assays` and 
+    metadata in `colData`. 
     If a data frame or a filepath is supplied, the table should be formatted 
     with features as columns and samples as rows (or the transpose). The
     column and row names should be the feature names and sample names
@@ -210,6 +212,8 @@ maaslin3(input_data,
     \item{cores}{How many cores to use when fitting models. (Using multiple
     cores will likely be faster only for large datasets or complex models.}
     \item{save_models}{Whether to return the fit models and save them to an
+    RData file.}
+    \item{save_plots_rds}{Whether to return the fit models and save them to an
     RData file.}
     \item{verbosity}{The level of verbosity for the \code{logging} package.}
     \item{summary_plot_balanced}{If set to TRUE the summary plot will 

--- a/man/maaslin_fit.Rd
+++ b/man/maaslin_fit.Rd
@@ -30,9 +30,9 @@ maaslin_fit(filtered_data,
             cores = 1,
             save_models = FALSE,
             data = NULL,
-            min_abundance = NULL,
-            min_prevalence = NULL,
-            min_variance = NULL)
+            min_abundance = 0,
+            min_prevalence = 0,
+            min_variance = 0)
 }
 \arguments{
     \item{filtered_data}{A data frame of filtered feature abundances. It

--- a/man/maaslin_log_arguments.Rd
+++ b/man/maaslin_log_arguments.Rd
@@ -47,6 +47,7 @@ maaslin_log_arguments(input_data,
                     max_pngs = 30,
                     cores = 1,
                     save_models = FALSE,
+                    save_plots_rds = FALSE,
                     verbosity = 'FINEST',
                     summary_plot_balanced = FALSE)
 }
@@ -185,6 +186,7 @@ maaslin_log_arguments(input_data,
     cores will likely be faster only for large datasets or complex models.}
     \item{save_models}{Whether to return the fit models and save them to an
     RData file.}
+    \item{save_plots_rds}{Whether to return the plots to an RDS file.}
     \item{verbosity}{The level of verbosity for the \code{logging} package.}
     \item{summary_plot_balanced}{If set to TRUE the summary plot will 
     show the top N features of each variable included in 

--- a/man/maaslin_plot_results.Rd
+++ b/man/maaslin_plot_results.Rd
@@ -33,7 +33,8 @@ maaslin_plot_results(output,
                     heatmap_vars = NULL,
                     plot_associations = TRUE,
                     max_pngs = 30,
-                    balanced = FALSE)
+                    balanced = FALSE,
+                    save_plots_rds = FALSE)
 }
 \arguments{
     \item{output}{The output folder to write results.}
@@ -101,6 +102,7 @@ maaslin_plot_results(output,
     \code{coef_plot_vars} where N is equal to: 
     \code{ceiling(summary_plot_first_n/length(coef_plot_vars))}. Will error
     if \code{coef_plot_vars} = \code{NULL}}
+    \item{save_plots_rds}{Whether to return the plots to an RDS file.}
 }
 \value{
 Results will be written to the \code{figures} folder within the folder

--- a/man/maaslin_plot_results_from_output.Rd
+++ b/man/maaslin_plot_results_from_output.Rd
@@ -33,7 +33,8 @@ maaslin_plot_results_from_output(output,
                                 heatmap_vars = NULL,
                                 plot_associations = TRUE,
                                 max_pngs = 30,
-                                balanced = FALSE)
+                                balanced = FALSE,
+                                save_plots_rds = FALSE)
 }
 \arguments{
     \item{output}{The output folder to write results.}
@@ -92,6 +93,7 @@ maaslin_plot_results_from_output(output,
     \code{coef_plot_vars} where N is equal to: 
     \code{ceiling(summary_plot_first_n/length(coef_plot_vars))}. Will error
     if \code{coef_plot_vars} = \code{NULL}}
+    \item{save_plots_rds}{Whether to return the plots to an RDS file.}
 }
 
 \value{

--- a/tests/testthat/test_Maaslin3.R
+++ b/tests/testthat/test_Maaslin3.R
@@ -60,4 +60,42 @@ fit_out <- maaslin3(input_data = se,
                     cores=1, 
                     verbosity = 'WARN')
 
+tse <- TreeSummarizedExperiment::TreeSummarizedExperiment(
+    assays = list(taxa_table = t(taxa_table)),
+    colData = metadata
+)
+
+fit_out <- maaslin3(input_data = tse, 
+                    input_metadata = metadata, 
+                    output = output_tmp, 
+                    normalization = 'TSS', 
+                    transform = 'LOG', 
+                    formula = '~ diagnosis + dysbiosis_state + antibiotics + age + reads', 
+                    save_models = FALSE, 
+                    plot_summary_plot = T, 
+                    plot_associations = T, 
+                    max_significance = 0.1, 
+                    augment = TRUE, 
+                    median_comparison_abundance = TRUE, 
+                    median_comparison_prevalence = FALSE, 
+                    cores=1, 
+                    verbosity = 'WARN')
+
+metadata <- as(metadata, "DataFrame")
+fit_out <- maaslin3(input_data = tse, 
+                    input_metadata = metadata, 
+                    output = output_tmp, 
+                    normalization = 'TSS', 
+                    transform = 'LOG', 
+                    formula = '~ diagnosis + dysbiosis_state + antibiotics + age + reads', 
+                    save_models = FALSE, 
+                    plot_summary_plot = T, 
+                    plot_associations = T, 
+                    max_significance = 0.1, 
+                    augment = TRUE, 
+                    median_comparison_abundance = TRUE, 
+                    median_comparison_prevalence = FALSE, 
+                    cores=1, 
+                    verbosity = 'WARN')
+
 unlink(output_tmp, recursive = T)

--- a/tests/testthat/test_maaslin_plot_results.R
+++ b/tests/testthat/test_maaslin_plot_results.R
@@ -45,7 +45,7 @@ expect_equal(list.files(file.path(output_tmp, 'figures',
              'var1_a_logistic.png')
 
 expect_equal(sort(list.files(file.path(output_tmp, 'figures'))),
-             sort(c("association_plots", "summary_plot_gg.RDS", "summary_plot.pdf", "summary_plot.png")))
+             sort(c("association_plots", "summary_plot.pdf", "summary_plot.png")))
 
 unlink(output_tmp, recursive = T)
 

--- a/vignettes/maaslin3_manual.Rmd
+++ b/vignettes/maaslin3_manual.Rmd
@@ -7,7 +7,9 @@ author:
   email: nearing@broadinstitute.org
 - name: Sagun Maharjan
   email: smaharjan@hsph.harvard.edu
-output: html_document
+output:
+  html_document: default
+  pdf_document: default
 vignette: >
     %\VignetteIndexEntry{Manual}
     %\VignetteEngine{knitr::rmarkdown}
@@ -38,7 +40,9 @@ bioRxiv 2024.12.13.628459; doi: https://doi.org/10.1101/2024.12.13.628459
 ### Support ###
 Check out the [MaAsLin 3
 tutorial](https://github.com/biobakery/biobakery/wiki/MaAsLin3) for an
-overview of analysis options and some example runs.
+overview of analysis options and some example runs. If using vignettes,
+users should start with the `maaslin3_tutorial.Rmd` vignette and then
+refer to the `maaslin3_manual.Rmd` vignette as necessary.
 
 If you have questions, please direct them to the [MaAsLin 3
 Forum](https://forum.biobakery.org/c/Downstream-analysis-and-statistics/maaslin)
@@ -77,19 +81,16 @@ function.
 
 #### Install using GitHub and devtools
 
-The latest development version of MaAsLin 3 can be installed from GitHub
-using the `devtools` package.
+The latest version of MaAsLin 3 can be installed from BiocManager.
 
 ```{r, eval=FALSE, cache = FALSE}
-# Install devtools if not present
-if (!require('devtools', character.only = TRUE)) {
-    install.packages('devtools')
-}
+if (!require("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
 
-# Install MaAsLin 3
-library("devtools")
-install_github("biobakery/maaslin3")
+BiocManager::install("biobakery/maaslin3")
 ```
+
+To compile vignettes yourself, specify `dependencies = TRUE`.
 
 ```{r, eval=TRUE, cache = FALSE, echo=FALSE}
 for (lib in c('maaslin3', 'dplyr', 'ggplot2', 'knitr')) {
@@ -394,6 +395,7 @@ maaslin_results = maaslin_fit(filtered_data,
                             standardized_metadata,
                             formula,
                             random_effects_formula,
+                            data = data,
                             median_comparison_abundance = TRUE,
                             median_comparison_prevalence = FALSE,
                             cores = 1)
@@ -896,6 +898,26 @@ complex models.)
 save them to an RData file.
 * `verbosity` (default `'FINEST'`): The level of verbosity for the 
 `logging` package.
+* `save_plots_rds` (default `FALSE`): Whether to save the plots as RDS files.
+
+## Tool comparison ##
+
+| Tool | Models differential abundance | \
+Models differential prevalence | Models allowed | Accounts for\
+compositionality | Can use experimental absolute abundance information |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| MaAsLin 3 | Yes | Yes, for any model type | Any lme4 model\
+(general mixed models), level-vs-level differences, group-wise differences, \
+feature-specific covariates, contrast tests | Yes | Yes |
+| MaAsLin 2 | Yes | Only insofar as it affects abundance | Fixed and random \
+effects (subset of general mixed models) | No | No |
+| ANCOM-BC2 | Yes | Only when completely absent in a group | Any lme4 model \
+(general mixed models), level-vs-level differences, group-wise differences, \
+contrast tests | Yes | No |
+| ALDEx2 | Yes | Only insofar as it affects abundance | Fixed \
+effects | Yes | No |
+| LinDA | Yes | Only insofar as it affects abundance | Any lme4 model \
+(general mixed models), group-wise differences, contrast tests | Yes | No |
 
 ## Troubleshooting ##
 

--- a/vignettes/maaslin3_tutorial.Rmd
+++ b/vignettes/maaslin3_tutorial.Rmd
@@ -37,7 +37,9 @@ bioRxiv 2024.12.13.628459; doi: https://doi.org/10.1101/2024.12.13.628459
 
 ### Support ###
 The user manual can be found
-[here](https://github.com/biobakery/maaslin3). If you have questions,
+[here](https://github.com/biobakery/maaslin3). If using vignettes,
+users should start with the `maaslin3_tutorial.Rmd` vignette and then
+refer to the `maaslin3_manual.Rmd` vignette as necessary. If you have questions,
 please direct them to the [MaAsLin
 Forum](https://forum.biobakery.org/c/Downstream-analysis-and-statistics/maaslin)
 
@@ -117,23 +119,16 @@ software and use `sessionInfo()` to make sure that you indeed have R >=
 
 ## 2. Installing MaAsLin 3 {#installing-maaslin-3}
 
-The latest development version of MaAsLin 3 can be installed from GitHub
-using the `devtools` package.
+The latest version of MaAsLin 3 can be installed from BiocManager.
 
 ```{r, eval=FALSE, cache = FALSE}
-if (!require('kableExtra', character.only = TRUE)) {
-    install.packages('kableExtra')
-}
+if (!require("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
 
-# Install devtools if not present
-if (!require('devtools', character.only = TRUE)) {
-    install.packages('devtools')
-}
-
-# Install MaAsLin 3
-library("devtools")
-install_github("biobakery/maaslin3")
+BiocManager::install("biobakery/maaslin3")
 ```
+
+To compile vignettes yourself, specify `dependencies = TRUE`.
 
 ```{r, eval=TRUE, cache = FALSE, echo=FALSE}
 for (lib in c('maaslin3', 'dplyr', 'ggplot2', 'knitr', 'kableExtra')) {
@@ -326,8 +321,8 @@ By default, many lines of information are printed while the models fit,
 but the verbosity can be changed with the `verbosity` argument (e.g., 
 `verbosity = 'WARN'`).
 
-MaAsLin 3 can also take as input a `SummarizedExperiment` object from
-BioConductor:
+MaAsLin 3 can also take as input a `SummarizedExperiment` or 
+`TreeSummarizedExperiment` object from BioConductor:
 
 ```{R, echo = TRUE, results = 'hide', warning = FALSE, eval = FALSE}
 se <- SummarizedExperiment(
@@ -814,6 +809,13 @@ head(fit_out$fit_data_abundance$results, n = 20) %>%
     kableExtra::scroll_box(width = "800px", height = "400px")
 ```
 
+#### Computationally estimated absolute abundance
+
+When using a purely computational approach to estimate absolute abundance
+(e.g., Nishijima et al. Cell 2024 with the function `MLP`), the abundance 
+table can be estimated
+and then run with the `normalization = 'NONE'` to avoid scaling the results.
+
 ### 4.2 Random effects (clustered samples) {#random-effects}
 
 Certain studies have a natural "grouping" of sample observations, such
@@ -832,7 +834,7 @@ where the same subject (column `participant_id`) can have multiple
 samples. We thus use `participant_id` as a random effect grouping
 variable in the model.
 
-```{R, echo = TRUE, results = 'hide', warning = FALSE}
+```{R, echo = TRUE, results = 'hide', warning = FALSE, messages = FALSE}
 # Subset to only CD cases for time; taxa are subset automatically
 fit_out <- maaslin3(
     input_data = taxa_table,
@@ -1101,7 +1103,8 @@ combination of the coefficients is significantly different from some constant
 on the right hand size (RHS). Specify a contrast matrix
 with column names matching the coefficient names and rows with the contrasts
 of interest. For each row $C^T$, the hypothesis $H_0:C^T\vec{\beta}=RHS$ 
-will be tested.
+will be tested. If no RHS is specified, a median test will be performed,
+and the median test RHS will be returned.
 
 Below, we test whether the UC and CD diagnosis coefficients are the same
 and whether the UC and CD dysbiosis coefficients are the same. The contrast
@@ -1164,6 +1167,26 @@ slashes may need to be removed):
     features) file
     * ``inst/extdata/HMP2_metadata.tsv`` is the path to your metadata file
     * ``command_line_output`` is the path to the folder to write the output
+
+## Tool comparison ##
+
+| Tool | Models differential abundance | \
+Models differential prevalence | Models allowed | Accounts for\
+compositionality | Can use experimental absolute abundance information |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| MaAsLin 3 | Yes | Yes, for any model type | Any lme4 model\
+(general mixed models), level-vs-level differences, group-wise differences, \
+feature-specific covariates, contrast tests | Yes | Yes |
+| MaAsLin 2 | Yes | Only insofar as it affects abundance | Fixed and random \
+effects (subset of general mixed models) | No | No |
+| ANCOM-BC2 | Yes | Only when completely absent in a group | Any lme4 model \
+(general mixed models), level-vs-level differences, group-wise differences, \
+contrast tests | Yes | No |
+| ALDEx2 | Yes | Only insofar as it affects abundance | Fixed \
+effects | Yes | No |
+| LinDA | Yes | Only insofar as it affects abundance | Any lme4 model \
+(general mixed models), group-wise differences, contrast tests | Yes | No |
+
 
 ```{R}
 sessionInfo()


### PR DESCRIPTION
Copied from Bioc resubmission:

1.	Removed GitHub installation instructions and recommended BiocManager installation instead.
2.	Mentioned that if the user wants to compile vignettes themselves, they should specify dependencies = TRUE.
3.	Replaced all “for” loops with vapply except for those that repeatedly modify the same object.
4.	Added explicit support for TreeSummarizedExperiment as input. This actually worked as input before, but we’ve now made it explicit and added a test case in test_Maaslin3.R.
5.	Added match.arg checks for parameters with a small set of character options. There is also substantial parameter checking in the documented functions (those intended for users) either directly or with maaslin_check_arguments.
6.	Clarified on the README and vignettes that users should start with the tutorial vignette and then refer to the manual vignette as necessary.
7.	Allowed handling of Bioconductor’s own data frame in S4Vectors named DataFrame.
8.	Included a table in the tutorial, manual, and README documenting the features available in MaAsLin 3, along with the other popular microbiome differential abundance tools MaAsLin 2, ALDEx2, ANCOM-BC2, and LinDA. In addition, our new preprint (https://doi.org/10.1101/2024.12.13.628459) documents other improvements and benchmarking. This preprint is linked in the citation section of the tutorial, manual, and README.