### PR TITLE
x-axis limits of summary plot increased

### DIFF
--- a/R/viz.R
+++ b/R/viz.R
@@ -265,11 +265,9 @@ make_coef_plot <- function(merged_results_sig,
         ggplot2::scale_x_continuous(
             breaks = custom_break_fun(n = 6),
             limits = c(
-                min(coef_plot_data$coef) - 
-                    quantile(coef_plot_data$stderr, 0.8),
-                max(coef_plot_data$coef) + 
-                    quantile(coef_plot_data$stderr, 0.8)
-            )
+              min(coef_plot_data$coef - coef_plot_data$stderr)*1.1, 
+              max(coef_plot_data$coef + coef_plot_data$stderr)*1.1
+              )
         ) +
         ggplot2::scale_shape_manual(name = "Association", values =
                                         c(21, 24)) +


### PR DESCRIPTION
summary plot sometimes would give issues with the error bars: if one of the edges of the bar were ouside the plot limit, it wouldn't be plotted. 
I suggest different way to set the x-axis plot limits. See resulting figures attached (**before fix** and **after fix** respectively). I can't share a full reprex given that the data used are still unpublished, but I'd be happy to discuss this, if needed.

Best,
Giacomo

<img width="685" height="715" alt="before fix" src="https://github.com/user-attachments/assets/cfc7f790-c4d7-4159-b121-1bf8343a5a25" />

<img width="687" height="661" alt="after fix" src="https://github.com/user-attachments/assets/5a196057-34d0-4ea5-a7e0-2972ff8e5584" />

