### PR TITLE
move (T)SE to Suggests. check_installed() where needed. Add test to c…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: MaAsLin 3 refines and extends generalized multivariate linear model
 License: MIT + file LICENSE
 Imports: dplyr, plyr, pbapply, lmerTest, parallel, lme4, optparse, logging,
         multcomp, ggplot2, RColorBrewer, patchwork, scales,
-        rlang, tibble, ggnewscale, survival, methods, BiocGenerics, SummarizedExperiment, TreeSummarizedExperiment
-Suggests: knitr, testthat (>= 2.1.0), rmarkdown, markdown, kableExtra
+        rlang, tibble, ggnewscale, survival, methods, BiocGenerics 
+Suggests: knitr, testthat (>= 2.1.0), rmarkdown, markdown, kableExtra, SummarizedExperiment, TreeSummarizedExperiment
 VignetteBuilder: knitr
 Collate: fit.R utility_scripts.R viz.R maaslin3.R
 URL: http://huttenhower.sph.harvard.edu/maaslin3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,13 +20,14 @@ export(preprocess_taxa_mtx)
 
 import("optparse")
 importFrom("stats", "as.formula", "coef", "glm", "lm", "na.exclude",
-    "p.adjust", "update", "relevel", "anova", "approx", "filter", "median",    "model.matrix", "pbeta", "quantile", "terms",    "update.formula", "var", "vcov", "rnorm", "cov", "setNames")
+    "p.adjust", "update", "relevel", "anova", "approx", "filter", "median",
+    "model.matrix", "pbeta", "quantile", "terms",
+    "update.formula", "var", "vcov", "rnorm", "cov", "setNames")
 importFrom("utils", "capture.output", "read.table", "write.table")
 importFrom("dplyr", "%>%")
 importFrom("plyr", "mapvalues")
 importFrom("stats", "sd", "na.omit")
 importFrom("utils","type.convert")
-importFrom("rlang", ".data")
+importFrom("rlang", ".data", "check_installed")
 importFrom("methods", "is")
 importFrom("survival", "strata", "coxph", "Surv")
-importFrom("TreeSummarizedExperiment", "TreeSummarizedExperiment")

--- a/R/utility_scripts.R
+++ b/R/utility_scripts.R
@@ -1211,17 +1211,20 @@ preprocess_taxa_mtx <- function(taxa_table, rna_table, rna_per_taxon) {
 
 maaslin_read_summarized_experiment_data <- 
     function(summarized_experiment, assay.type = 1) {
-    if (!inherits(summarized_experiment, "SummarizedExperiment")) {
-        stop("Input must be a SummarizedExperiment object")
+        
+        rlang::check_installed("SummarizedExperiment")
+        
+        if (!inherits(summarized_experiment, "SummarizedExperiment")) {
+            stop("Input must be a SummarizedExperiment object")
+        }
+        
+        data <- as.data.frame(t(SummarizedExperiment::assay(
+            summarized_experiment, assay.type)))
+        metadata <- as.data.frame(
+            SummarizedExperiment::colData(summarized_experiment))
+        return(list(
+            "data" = data,
+            "metadata" = metadata
+        ))
     }
-    
-    data <- as.data.frame(t(SummarizedExperiment::assay(
-        summarized_experiment, assay.type)))
-    metadata <- as.data.frame(
-        SummarizedExperiment::colData(summarized_experiment))
-    return(list(
-        "data" = data,
-        "metadata" = metadata
-    ))
-}
 

--- a/tests/testthat/test_maaslin_read_data.R
+++ b/tests/testthat/test_maaslin_read_data.R
@@ -40,3 +40,23 @@ expect_that(data_in_new$metadata, equals(metadata))
 expect_that(data_in_new$feature_specific_covariate, equals(covar_data))
 expect_that(data_in_new$unscaled_abundance, equals(unscaled))
 
+test_that("Can read SE", {
+    
+    # fake data
+    taxa_mat = matrix(rnorm(12), nrow = 3,
+                      dimnames = list(paste0("ft_", 1:3),
+                                      paste0("samp_", 1:4)))
+    
+    m = data.frame(grp = sample(0:1, size = 4, replace = TRUE),
+                   x = rnorm(4),
+                   row.names = paste0("samp_", 1:4))
+    
+    # construct SE here
+    se = SummarizedExperiment::SummarizedExperiment(assays = list(values = taxa_mat),
+                                                    colData = m)
+     
+    se_read = maaslin_read_summarized_experiment_data(se)
+
+    expect_equal(se_read, list(data = as.data.frame(t(taxa_mat)), metadata = m))
+})
+


### PR DESCRIPTION
We welcome feedback and issue reporting for all bioBakery tools through our [Discourse site](https://forum.biobakery.org/c/pull-request/featurepull-request/). For users that would like to directly contribute to the [tools](https://github.com/biobakery/) we are happy to field PRs to address **bug fixes**. Please note the turn around time on our end might be a bit long to field these but that does not mean we don't value the contribution! We currently **don't** accept PRs to add **new functionality** to tools but we would be happy to receive your feedback on [Discourse](https://forum.biobakery.org/c/pull-request/featurepull-request/).

Also, we will make sure to attribute your contribution in our User’s manual(README.md) and in any associated paper Acknowledgements.


## Description

This PR:

* moves `TreeSummarizedExperiment` and `SummarizedExperiment` to Suggests
* checks if the necessary packages are installed with `rlang::check_installed()` in the corresponding reader function when the user passes in an SE
* Adds a test for reading SEs

I discussed this change with Will over Slack. This lowers the number of required dependencies from 102 to 64 and lowers the time required to attach the package (`system.time({library(maaslin3)})`) from 4.686s to 0.734s (on my system).

```r
havel::plot_deps_graph("biobakery/MaAsLin3@0071631")
```

<img width="960" height="720" alt="m3_bb" src="https://github.com/user-attachments/assets/bbfdad06-64de-4525-a073-d393c5a91b12" />

```r
havel::plot_deps_graph("andrewGhazi/MaAsLin3@suggestSE")
```

<img width="960" height="720" alt="m3_no_SE" src="https://github.com/user-attachments/assets/ff36dca2-16c7-41bd-b3c8-16f8587c7eac" />
