### PR TITLE
Miscellaneous small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 /vignettes/ordered_outputs
 /vignettes/demo_output_ratio
 /vignettes/demo_output_rna
+maaslin3.Rproj
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: MaAsLin 3 refines and extends generalized multivariate linear model
 License: MIT + file LICENSE
 Imports: dplyr, plyr, pbapply, lmerTest, parallel, lme4, optparse, logging,
         multcomp, ggplot2, RColorBrewer, patchwork, scales,
-        rlang, tibble, ggnewscale, survival, methods, BiocGenerics, SummarizedExperiment, TreeSummarizedExperiment
+        rlang, tibble, ggnewscale, survival, methods, BiocGenerics, SummarizedExperiment, TreeSummarizedExperiment, reformulas
 Suggests: knitr, testthat (>= 2.1.0), rmarkdown, markdown, kableExtra
 VignetteBuilder: knitr
 Collate: fit.R utility_scripts.R viz.R maaslin3.R

--- a/R/fit.R
+++ b/R/fit.R
@@ -104,7 +104,7 @@ get_fixed_effects <-
                 names_to_include[names_to_include != "(Intercept)"]
         } else {
             # Random effects
-            patterns <- paste0("(", unlist(lme4::findbars(formula(
+            patterns <- paste0("(", unlist(reformulas::findbars(formula(
                 gsub("^expr ", "", safe_deparse(formula))
             ))), ")")
             
@@ -2235,7 +2235,7 @@ fit.model <- function(features,
     
     if (small_random_effects & model == 'logistic') {
         fixed_part <- lme4::nobars(formula)
-        random_terms <- lme4::findbars(formula)
+        random_terms <- reformulas::findbars(formula)
         if (length(random_terms) > 0) {
             grouping <- unique(
                 vapply(random_terms, function(x) deparse(x[[3]]), 

--- a/R/maaslin3.R
+++ b/R/maaslin3.R
@@ -2304,7 +2304,7 @@ maaslin_fit <- function(filtered_data,
     
     if (!is.null(fit_data_prevalence)) {
         if (!is.null(random_effects_formula)) {
-            bars <- lme4::findbars(random_effects_formula)
+            bars <- reformulas::findbars(random_effects_formula)
             random_names <- vapply(bars, function(x) deparse(x[[3]]), 
                 FUN.VALUE = character(1))
             for (random_name in random_names) {

--- a/R/maaslin3.R
+++ b/R/maaslin3.R
@@ -834,9 +834,21 @@ maaslin_log_arguments <- function(input_data,
     }
 
     logging::logReset()
+    
     logging::basicConfig(level = verbosity)
+    
+    logging::removeHandler("basic.stdout")
+    
+    logging::addHandler(logging::writeToConsole,
+                        handler = "basic.stdout",
+                        logger = "",
+                        level = 20,
+                        formatter = nrw_fmt)
+    
     logging::addHandler(logging::writeToFile,
-                        file = log_file, level = verbosity)
+                        file = log_file, level = verbosity,
+                        formatter = nrw_fmt)
+    
     logging::setLevel(20, logging::getHandler('basic.stdout'))
 
     logging::loginfo("Writing function arguments to log file")

--- a/R/utility_scripts.R
+++ b/R/utility_scripts.R
@@ -1225,3 +1225,17 @@ maaslin_read_summarized_experiment_data <-
     ))
 }
 
+nrw_ts = function(ts) {
+    as.POSIXct(ts) |>  
+        format(format = "%Y-%m-%d %H:%M:%OS2")
+}
+
+nrw_fmt = function(record) {
+    # 5-6 digits of precision on the timestamp is verbose and makes it hard to
+    # read. Limit it to two digits.
+    
+    msg <- trimws(record$msg)
+    text <- paste(nrw_ts(record$timestamp), paste(record$levelname, record$logger, 
+                                          msg, sep = ":"))
+    return(text)
+}


### PR DESCRIPTION
## Description

This PR includes a few small tweaks for the convenience of users and developers:

1. It changes the formatting of timestamps in logs to be consistently limited to hundredths of a second. That makes the timestamps easier to read and a consistent width.
2. It adds reformulas to the Imports, reflecting the same change in lme4. `reformulas` is used for the `findbars()` function, which used to live in `lme4`. This avoids a warning when the package is loaded.
3. Adds `maaslin3.Rproj` to .gitignore to avoid messages for developers working with the repo in RStudio.
